### PR TITLE
[feature/DB-99]: 산책로 검색, 단건 조회 API 수정

### DIFF
--- a/app-external-api/src/main/java/com/dongsan/domains/bookmark/usecase/BookmarkUseCase.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/bookmark/usecase/BookmarkUseCase.java
@@ -1,6 +1,7 @@
 package com.dongsan.domains.bookmark.usecase;
 
 import com.dongsan.common.annotation.UseCase;
+import com.dongsan.common.error.code.WalkwayErrorCode;
 import com.dongsan.domains.bookmark.dto.BookmarksWithMarkedWalkwayDTO;
 import com.dongsan.domains.bookmark.dto.param.GetBookmarkDetailParam;
 import com.dongsan.domains.bookmark.dto.request.BookmarkNameRequest;
@@ -87,6 +88,9 @@ public class BookmarkUseCase {
 
     @Transactional(readOnly = true)
     public BookmarksWithMarkedWalkwayResponse getBookmarksWithMarkedWalkway(Long memberId, Long walkwayId) {
+        if (!walkwayQueryService.existsByWalkwayId(walkwayId)) {
+            throw new CustomException(WalkwayErrorCode.WALKWAY_NOT_FOUND);
+        }
         List<BookmarksWithMarkedWalkwayDTO> bookmarks = bookmarkQueryService.getBookmarksWithMarkedWalkway(walkwayId, memberId);
         return BookmarksWithMarkedWalkwayMapper.toBookmarksWithMarkedWalkwayResponse(bookmarks);
     }

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/controller/ReviewController.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/controller/ReviewController.java
@@ -2,7 +2,6 @@ package com.dongsan.domains.walkway.controller;
 
 import com.dongsan.common.apiResponse.ResponseFactory;
 import com.dongsan.common.apiResponse.SuccessResponse;
-import com.dongsan.common.validation.annotation.ExistWalkway;
 import com.dongsan.domains.auth.security.oauth2.dto.CustomOAuth2User;
 import com.dongsan.domains.walkway.dto.request.CreateReviewRequest;
 import com.dongsan.domains.walkway.dto.response.CreateReviewResponse;
@@ -35,7 +34,7 @@ public class ReviewController {
     @Operation(summary = "리뷰 작성")
     @PostMapping("/{walkwayId}/review")
     public ResponseEntity<SuccessResponse<CreateReviewResponse>> createReview(
-            @ExistWalkway @PathVariable Long walkwayId,
+            @PathVariable Long walkwayId,
             @Validated @RequestBody CreateReviewRequest createReviewRequest,
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ) {
@@ -45,7 +44,7 @@ public class ReviewController {
     @Operation(summary = "리뷰 내용 보기")
     @GetMapping("/{walkwayId}/review/content")
     public ResponseEntity<SuccessResponse<GetWalkwayReviewsResponse>> getWalkwayReviews(
-            @ExistWalkway @PathVariable Long walkwayId,
+            @PathVariable Long walkwayId,
             @RequestParam String type,
             @RequestParam(required = false) Long lastId,
             @RequestParam(required = false, defaultValue = "5") Byte rating,
@@ -57,7 +56,7 @@ public class ReviewController {
     @Operation(summary = "리뷰 별점 보기")
     @GetMapping("/{walkwayId}/review/rating")
     public ResponseEntity<SuccessResponse<GetWalkwayRatingResponse>> getWalkwaysRating(
-            @ExistWalkway @PathVariable Long walkwayId
+            @PathVariable Long walkwayId
     ) {
         return ResponseFactory.ok(walkwayReviewUseCase.getWalkwayRating(walkwayId));
     }

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/controller/WalkwayController.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/controller/WalkwayController.java
@@ -11,9 +11,11 @@ import com.dongsan.domains.walkway.dto.request.UpdateWalkwayRequest;
 import com.dongsan.domains.walkway.dto.response.CreateWalkwayResponse;
 import com.dongsan.domains.walkway.dto.response.GetWalkwaySearchResponse;
 import com.dongsan.domains.walkway.dto.response.GetWalkwayWithLikedResponse;
+import com.dongsan.domains.walkway.entity.Walkway;
 import com.dongsan.domains.walkway.usecase.WalkwayUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -64,12 +66,11 @@ public class WalkwayController {
             @RequestParam Double longitude,
             @RequestParam Double distance,
             @RequestParam(required = false) Long lastId,
-            @RequestParam(defaultValue = "0") Double rating,
-            @RequestParam(defaultValue = "0") Integer likes,
             @RequestParam(defaultValue = "10") Integer size,
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ) {
-        return ResponseFactory.ok(walkwayUseCase.getWalkwaysSearch(customOAuth2User.getMemberId(), type, latitude, longitude, distance, hashtags, lastId, rating, likes, size));
+        List<Walkway> walkways = walkwayUseCase.getWalkwaysSearch(customOAuth2User.getMemberId(), type, latitude, longitude, distance, hashtags, lastId, size);
+        return ResponseFactory.ok(new GetWalkwaySearchResponse(walkways, size));
     }
 
     @Operation(summary = "북마크 목록 보기(산책로 마크 여부 포함)")

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/controller/WalkwayController.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/controller/WalkwayController.java
@@ -2,7 +2,6 @@ package com.dongsan.domains.walkway.controller;
 
 import com.dongsan.common.apiResponse.ResponseFactory;
 import com.dongsan.common.apiResponse.SuccessResponse;
-import com.dongsan.common.validation.annotation.ExistWalkway;
 import com.dongsan.domains.auth.security.oauth2.dto.CustomOAuth2User;
 import com.dongsan.domains.bookmark.dto.response.BookmarksWithMarkedWalkwayResponse;
 import com.dongsan.domains.bookmark.usecase.BookmarkUseCase;
@@ -77,7 +76,7 @@ public class WalkwayController {
     @Operation(summary = "북마크 목록 보기(산책로 마크 여부 포함)")
     @GetMapping("/{walkwayId}/bookmarks")
     public ResponseEntity<SuccessResponse<BookmarksWithMarkedWalkwayResponse>> getBookmarksWithMarkedWalkway(
-            @ExistWalkway @PathVariable Long walkwayId,
+            @PathVariable Long walkwayId,
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ) {
         return ResponseFactory.ok(bookmarkUseCase.getBookmarksWithMarkedWalkway(customOAuth2User.getMemberId(), walkwayId));
@@ -86,7 +85,7 @@ public class WalkwayController {
     @Operation(summary = "산책로 수정")
     @PutMapping("/{walkwayId}")
     public ResponseEntity<Void> updateWalkway(
-            @ExistWalkway @PathVariable Long walkwayId,
+            @PathVariable Long walkwayId,
             @RequestBody UpdateWalkwayRequest updateWalkwayRequest,
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ) {

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/controller/WalkwayController.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/controller/WalkwayController.java
@@ -11,6 +11,7 @@ import com.dongsan.domains.walkway.dto.response.CreateWalkwayResponse;
 import com.dongsan.domains.walkway.dto.response.GetWalkwaySearchResponse;
 import com.dongsan.domains.walkway.dto.response.GetWalkwayWithLikedResponse;
 import com.dongsan.domains.walkway.entity.Walkway;
+import com.dongsan.domains.walkway.usecase.LikedWalkwayUseCase;
 import com.dongsan.domains.walkway.usecase.WalkwayUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -37,6 +38,7 @@ public class WalkwayController {
 
     private final WalkwayUseCase walkwayUseCase;
     private final BookmarkUseCase bookmarkUseCase;
+    private final LikedWalkwayUseCase likedWalkwayUseCase;
 
     @Operation(summary = "산책로 등록")
     @PostMapping("")
@@ -70,7 +72,8 @@ public class WalkwayController {
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ) {
         List<Walkway> walkways = walkwayUseCase.getWalkwaysSearch(customOAuth2User.getMemberId(), type, latitude, longitude, distance, hashtags, lastId, size);
-        return ResponseFactory.ok(new GetWalkwaySearchResponse(walkways, size));
+        List<Boolean> likedWalkways = likedWalkwayUseCase.existsLikedWalkways(customOAuth2User.getMemberId(), walkways);
+        return ResponseFactory.ok(new GetWalkwaySearchResponse(walkways, likedWalkways, size));
     }
 
     @Operation(summary = "북마크 목록 보기(산책로 마크 여부 포함)")

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/controller/WalkwayController.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/controller/WalkwayController.java
@@ -60,13 +60,13 @@ public class WalkwayController {
     @Operation(summary = "산책로 검색")
     @GetMapping("")
     public ResponseEntity<SuccessResponse<GetWalkwaySearchResponse>> getWalkwaysSearch(
-            @RequestParam String type,
-            @RequestParam(defaultValue = "") String hashtags,
-            @RequestParam Double latitude,
-            @RequestParam Double longitude,
-            @RequestParam Double distance,
-            @RequestParam(required = false) Long lastId,
-            @RequestParam(defaultValue = "10") Integer size,
+            @RequestParam(name = "type") String type,
+            @RequestParam(name = "hashtags", defaultValue = "") String hashtags,
+            @RequestParam(name = "latitude") Double latitude,
+            @RequestParam(name = "longitude") Double longitude,
+            @RequestParam(name = "distance") Double distance,
+            @RequestParam(name = "lastId", required = false) Long lastId,
+            @RequestParam(name = "size", defaultValue = "10") Integer size,
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ) {
         List<Walkway> walkways = walkwayUseCase.getWalkwaysSearch(customOAuth2User.getMemberId(), type, latitude, longitude, distance, hashtags, lastId, size);

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/controller/WalkwayController.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/controller/WalkwayController.java
@@ -54,7 +54,8 @@ public class WalkwayController {
             @PathVariable Long walkwayId,
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ) {
-        return ResponseFactory.ok(walkwayUseCase.getWalkwayWithLiked(walkwayId, customOAuth2User.getMemberId()));
+        Walkway walkway = walkwayUseCase.getWalkwayWithLiked(walkwayId, customOAuth2User.getMemberId());
+        return ResponseFactory.ok(new GetWalkwayWithLikedResponse(walkway));
     }
 
     @Operation(summary = "산책로 검색")

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/dto/response/GetWalkwaySearchResponse.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/dto/response/GetWalkwaySearchResponse.java
@@ -9,16 +9,14 @@ import lombok.Builder;
 @Builder
 public record GetWalkwaySearchResponse(
         List<WalkwayResponse> walkways,
-        Long nextCursor,
-        int size
+        Long nextCursor
 ) {
     public GetWalkwaySearchResponse(List<Walkway> walkways, Integer size) {
         this(
                 walkways.stream()
                         .map(WalkwayResponse::new)
                         .collect(Collectors.toList()),
-                walkways.size() == size ? walkways.get(walkways.size()-1).getId() : -1,
-                walkways.size()
+                walkways.size() == size ? walkways.get(walkways.size()-1).getId() : -1
         );
     }
 

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/dto/response/GetWalkwaySearchResponse.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/dto/response/GetWalkwaySearchResponse.java
@@ -4,6 +4,7 @@ import com.dongsan.domains.walkway.entity.Walkway;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.Builder;
 
 @Builder
@@ -11,11 +12,11 @@ public record GetWalkwaySearchResponse(
         List<WalkwayResponse> walkways,
         Long nextCursor
 ) {
-    public GetWalkwaySearchResponse(List<Walkway> walkways, Integer size) {
+    public GetWalkwaySearchResponse(List<Walkway> walkways, List<Boolean> likedWalkways, Integer size) {
         this(
-                walkways.stream()
-                        .map(WalkwayResponse::new)
-                        .collect(Collectors.toList()),
+                IntStream.range(0, walkways.size())
+                        .mapToObj(i -> new WalkwayResponse(walkways.get(i), likedWalkways.get(i)))
+                        .toList(),
                 walkways.size() == size ? walkways.get(walkways.size()-1).getId() : -1
         );
     }
@@ -33,7 +34,7 @@ public record GetWalkwaySearchResponse(
             List<Double> location,
             String registerDate
     ) {
-        public WalkwayResponse(Walkway walkway) {
+        public WalkwayResponse(Walkway walkway, Boolean isLike) {
             this(
                     walkway.getId(),
                     walkway.getName(),
@@ -41,7 +42,7 @@ public record GetWalkwaySearchResponse(
                     walkway.getHashtagWalkways().stream()
                             .map(hashtagWalkway -> "#" + hashtagWalkway.getHashtag().getName())
                             .collect(Collectors.toList()),
-                    !walkway.getLikedWalkways().isEmpty(),
+                    isLike,
                     walkway.getLikeCount(),
                     walkway.getReviewCount(),
                     walkway.getRating(),

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/dto/response/GetWalkwaySearchResponse.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/dto/response/GetWalkwaySearchResponse.java
@@ -1,6 +1,9 @@
 package com.dongsan.domains.walkway.dto.response;
 
+import com.dongsan.domains.walkway.entity.Walkway;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Builder;
 
 @Builder
@@ -8,16 +11,44 @@ public record GetWalkwaySearchResponse(
         List<WalkwayResponse> walkways,
         Long nextCursor
 ) {
-    @Builder
-    public record WalkwayResponse(
-        String name,
-        Double distance,
-        List<String> hashTags,
-        Boolean isLike,
-        Integer likeCount,
-        Integer reviewCount,
-        Double rating
-    ) {
+    public GetWalkwaySearchResponse(List<Walkway> walkways, Integer size) {
+        this(
+                walkways.stream()
+                        .map(WalkwayResponse::new)
+                        .collect(Collectors.toList()),
+                walkways.size() > size ? walkways.get(walkways.size()-1).getId() : -1
+        );
+    }
 
+    public record WalkwayResponse(
+            Long walkwayId,
+            String name,
+            Double distance,
+            List<String> hashtags,
+            Boolean isLike,
+            Integer likeCount,
+            Integer reviewCount,
+            Double rating,
+            String courseImageUrl,
+            List<Double> location,
+            String registerDate
+    ) {
+        public WalkwayResponse(Walkway walkway) {
+            this(
+                    walkway.getId(),
+                    walkway.getName(),
+                    walkway.getDistance(),
+                    walkway.getHashtagWalkways().stream()
+                            .map(hashtagWalkway -> hashtagWalkway.getHashtag().getName())
+                            .collect(Collectors.toList()),
+                    !walkway.getLikedWalkways().isEmpty(),
+                    walkway.getLikeCount(),
+                    walkway.getReviewCount(),
+                    walkway.getRating(),
+                    walkway.getCourseImageUrl(),
+                    List.of(walkway.getStartLocation().getX(), walkway.getStartLocation().getY()),
+                    walkway.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd"))
+            );
+        }
     }
 }

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/dto/response/GetWalkwaySearchResponse.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/dto/response/GetWalkwaySearchResponse.java
@@ -39,7 +39,7 @@ public record GetWalkwaySearchResponse(
                     walkway.getName(),
                     walkway.getDistance(),
                     walkway.getHashtagWalkways().stream()
-                            .map(hashtagWalkway -> hashtagWalkway.getHashtag().getName())
+                            .map(hashtagWalkway -> "#" + hashtagWalkway.getHashtag().getName())
                             .collect(Collectors.toList()),
                     !walkway.getLikedWalkways().isEmpty(),
                     walkway.getLikeCount(),

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/dto/response/GetWalkwaySearchResponse.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/dto/response/GetWalkwaySearchResponse.java
@@ -9,14 +9,16 @@ import lombok.Builder;
 @Builder
 public record GetWalkwaySearchResponse(
         List<WalkwayResponse> walkways,
-        Long nextCursor
+        Long nextCursor,
+        int size
 ) {
     public GetWalkwaySearchResponse(List<Walkway> walkways, Integer size) {
         this(
                 walkways.stream()
                         .map(WalkwayResponse::new)
                         .collect(Collectors.toList()),
-                walkways.size() > size ? walkways.get(walkways.size()-1).getId() : -1
+                walkways.size() == size ? walkways.get(walkways.size()-1).getId() : -1,
+                walkways.size()
         );
     }
 

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/dto/response/GetWalkwayWithLikedResponse.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/dto/response/GetWalkwayWithLikedResponse.java
@@ -1,12 +1,16 @@
 package com.dongsan.domains.walkway.dto.response;
 
-import java.util.List;
-import lombok.Builder;
+import static com.dongsan.domains.walkway.mapper.LineStringMapper.toList;
 
-@Builder
+import com.dongsan.domains.walkway.entity.Walkway;
+import com.dongsan.domains.walkway.enums.ExposeLevel;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public record GetWalkwayWithLikedResponse(
         String date,
-        String time,
+        Integer time,
         Double distance,
         String name,
         String memo,
@@ -14,7 +18,24 @@ public record GetWalkwayWithLikedResponse(
         Boolean isLiked,
         Integer reviewCount,
         List<String> hashTags,
-        Boolean accessLevel,
+        ExposeLevel accessLevel,
         List<List<Double>> course
 ) {
+    public GetWalkwayWithLikedResponse(Walkway walkway) {
+        this (
+                walkway.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")),
+                walkway.getTime(),
+                walkway.getDistance(),
+                walkway.getName(),
+                walkway.getMemo(),
+                walkway.getRating(),
+                !walkway.getLikedWalkways().isEmpty(),
+                walkway.getReviewCount(),
+                walkway.getHashtagWalkways().stream()
+                        .map(hashtagWalkway -> "#" + hashtagWalkway.getHashtag().getName())
+                        .collect(Collectors.toList()),
+                walkway.getExposeLevel(),
+                toList(walkway.getCourse())
+        );
+    }
 }

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/mapper/WalkwayMapper.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/mapper/WalkwayMapper.java
@@ -6,7 +6,6 @@ import static com.dongsan.domains.walkway.mapper.LineStringMapper.toList;
 import com.dongsan.domains.member.entity.Member;
 import com.dongsan.domains.walkway.dto.request.CreateWalkwayRequest;
 import com.dongsan.domains.walkway.dto.response.CreateWalkwayResponse;
-import com.dongsan.domains.walkway.dto.response.GetWalkwaySearchResponse;
 import com.dongsan.domains.walkway.dto.response.GetWalkwayWithLikedResponse;
 import com.dongsan.domains.walkway.entity.Walkway;
 import com.dongsan.domains.walkway.enums.ExposeLevel;
@@ -76,34 +75,6 @@ public class WalkwayMapper {
                         .collect(Collectors.toList()))
                 .accessLevel(walkway.getExposeLevel().toBoolean())
                 .course(toList(walkway.getCourse()))
-                .build();
-    }
-
-    public static GetWalkwaySearchResponse toGetWalkwaySearchResponse (
-        List<Walkway> walkways,
-        int size
-    ) {
-        return GetWalkwaySearchResponse.builder()
-                .nextCursor(walkways.size() > size ? walkways.get(walkways.size()-1).getId() : -1)
-                .walkways(walkways.stream()
-                        .map(WalkwayMapper::toWalkwayResponse)
-                        .collect(Collectors.toList()))
-                .build();
-    }
-
-    public static GetWalkwaySearchResponse.WalkwayResponse toWalkwayResponse(
-            Walkway walkway
-    ) {
-        return GetWalkwaySearchResponse.WalkwayResponse.builder()
-                .name(walkway.getName())
-                .distance(walkway.getDistance())
-                .hashTags(walkway.getHashtagWalkways().stream()
-                        .map(walkwayHashtag -> walkwayHashtag.getWalkway().getName())
-                        .collect(Collectors.toList()))
-                .isLike(!walkway.getLikedWalkways().isEmpty())
-                .likeCount(walkway.getLikeCount())
-                .reviewCount(walkway.getReviewCount())
-                .rating(walkway.getRating())
                 .build();
     }
 }

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/mapper/WalkwayMapper.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/mapper/WalkwayMapper.java
@@ -1,16 +1,13 @@
 package com.dongsan.domains.walkway.mapper;
 
 import static com.dongsan.domains.walkway.mapper.LineStringMapper.toLineString;
-import static com.dongsan.domains.walkway.mapper.LineStringMapper.toList;
 
 import com.dongsan.domains.member.entity.Member;
 import com.dongsan.domains.walkway.dto.request.CreateWalkwayRequest;
 import com.dongsan.domains.walkway.dto.response.CreateWalkwayResponse;
-import com.dongsan.domains.walkway.dto.response.GetWalkwayWithLikedResponse;
 import com.dongsan.domains.walkway.entity.Walkway;
 import com.dongsan.domains.walkway.enums.ExposeLevel;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
@@ -54,27 +51,6 @@ public class WalkwayMapper {
     public static CreateWalkwayResponse toCreateWalkwayResponse(Walkway walkway) {
         return CreateWalkwayResponse.builder()
                 .walkwayId(walkway.getId())
-                .build();
-    }
-
-    public static GetWalkwayWithLikedResponse toGetWalkwayWithLikedResponse(
-            Walkway walkway
-    ) {
-
-        return GetWalkwayWithLikedResponse.builder()
-                .date(walkway.getCreatedAt().toLocalDate().toString())
-                .time(walkway.getTime().toString())
-                .distance(walkway.getDistance())
-                .name(walkway.getName())
-                .memo(walkway.getMemo())
-                .rating(walkway.getRating())
-                .isLiked(!walkway.getLikedWalkways().isEmpty())
-                .reviewCount(walkway.getReviewCount())
-                .hashTags(walkway.getHashtagWalkways().stream()
-                        .map(hashtagWalkway -> hashtagWalkway.getHashtag().getName())
-                        .collect(Collectors.toList()))
-                .accessLevel(walkway.getExposeLevel().toBoolean())
-                .course(toList(walkway.getCourse()))
                 .build();
     }
 }

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/usecase/LikedWalkwayUseCase.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/usecase/LikedWalkwayUseCase.java
@@ -7,8 +7,12 @@ import com.dongsan.domains.walkway.entity.LikedWalkway;
 import com.dongsan.domains.walkway.entity.Walkway;
 import com.dongsan.domains.walkway.mapper.LikedWalkwayMapper;
 import com.dongsan.domains.walkway.service.LikedWalkwayCommandService;
+import com.dongsan.domains.walkway.service.LikedWalkwayQueryService;
 import com.dongsan.domains.walkway.service.WalkwayQueryService;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
@@ -16,7 +20,9 @@ public class LikedWalkwayUseCase {
     private final LikedWalkwayCommandService likedWalkwayCommandService;
     private final MemberQueryService memberQueryService;
     private final WalkwayQueryService walkwayQueryService;
+    private final LikedWalkwayQueryService likedWalkwayQueryService;
 
+    @Transactional
     public void createLikedWalkway(Long memberId, Long walkwayId) {
         Member member = memberQueryService.getMember(memberId);
         Walkway walkway = walkwayQueryService.getWalkway(walkwayId);
@@ -29,6 +35,7 @@ public class LikedWalkwayUseCase {
         }
     }
 
+    @Transactional
     public void deleteLikedWalkway(Long memberId, Long walkwayId) {
         Member member = memberQueryService.getMember(memberId);
         Walkway walkway = walkwayQueryService.getWalkway(walkwayId);
@@ -38,5 +45,11 @@ public class LikedWalkwayUseCase {
             likedWalkwayCommandService.deleteLikedWalkway(member, walkway);
             walkway.removeLikedWalkway();
         }
+    }
+
+    public List<Boolean> existsLikedWalkways(Long memberId, List<Walkway> walkways) {
+        return walkways.stream()
+                .map(walkway -> likedWalkwayQueryService.existByMemberIdAndWalkwayId(memberId, walkway.getId()))
+                .collect(Collectors.toList());
     }
 }

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/usecase/WalkwayReviewUseCase.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/usecase/WalkwayReviewUseCase.java
@@ -1,6 +1,7 @@
 package com.dongsan.domains.walkway.usecase;
 
 import com.dongsan.common.annotation.UseCase;
+import com.dongsan.common.error.code.WalkwayErrorCode;
 import com.dongsan.domains.member.entity.Member;
 import com.dongsan.domains.member.service.MemberQueryService;
 import com.dongsan.domains.review.dto.RatingCount;
@@ -46,6 +47,10 @@ public class WalkwayReviewUseCase {
     }
 
     public GetWalkwayReviewsResponse getWalkwayReviews(String type, Long lastId, Long walkwayId, Byte rating, Integer size) {
+        if (!walkwayQueryService.existsByWalkwayId(walkwayId)) {
+            throw new CustomException(WalkwayErrorCode.WALKWAY_NOT_FOUND);
+        }
+
         List<Review> reviews;
 
         switch (type) {

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/usecase/WalkwayReviewUseCase.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/usecase/WalkwayReviewUseCase.java
@@ -20,6 +20,7 @@ import com.dongsan.common.error.code.ReviewErrorCode;
 import com.dongsan.common.error.exception.CustomException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
@@ -31,6 +32,7 @@ public class WalkwayReviewUseCase {
     private final ReviewQueryService reviewQueryService;
     private final WalkwayCommandService walkwayCommandService;
 
+    @Transactional
     public CreateReviewResponse createReview(Long memberId, Long walkwayId, CreateReviewRequest createReviewRequest) {
         Member member = memberQueryService.getMember(memberId);
 
@@ -40,7 +42,8 @@ public class WalkwayReviewUseCase {
 
         review = reviewCommandService.createReview(review);
 
-        walkway.updateRatingAndReviewCount(review.getRating());
+        Integer count = reviewQueryService.getWalkwayReviewCount(walkwayId);
+        walkway.updateRatingAndReviewCount(review.getRating(), count);
         walkwayCommandService.createWalkway(walkway);
 
         return ReviewMapper.toCreateReviewResponse(review);

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/usecase/WalkwayUseCase.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/usecase/WalkwayUseCase.java
@@ -13,7 +13,6 @@ import com.dongsan.domains.walkway.dto.SearchWalkwayRating;
 import com.dongsan.domains.walkway.dto.request.CreateWalkwayRequest;
 import com.dongsan.domains.walkway.dto.request.UpdateWalkwayRequest;
 import com.dongsan.domains.walkway.dto.response.CreateWalkwayResponse;
-import com.dongsan.domains.walkway.dto.response.GetWalkwayWithLikedResponse;
 import com.dongsan.domains.walkway.entity.Walkway;
 import com.dongsan.domains.walkway.mapper.WalkwayMapper;
 import com.dongsan.domains.walkway.service.WalkwayCommandService;
@@ -54,13 +53,13 @@ public class WalkwayUseCase {
     }
 
     @Transactional(readOnly = true)
-    public GetWalkwayWithLikedResponse getWalkwayWithLiked(Long walkwayId, Long memberId) {
+    public Walkway getWalkwayWithLiked(Long walkwayId, Long memberId) {
         Walkway walkway = walkwayQueryService.getWalkwayWithHashtagAndLike(memberId, walkwayId);
         if (walkway == null) {
             throw new CustomException(WalkwayErrorCode.INVALID_COURSE);
         }
 
-        return WalkwayMapper.toGetWalkwayWithLikedResponse(walkway);
+        return walkway;
     }
 
     @Transactional(readOnly = true)

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/usecase/WalkwayUseCase.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/usecase/WalkwayUseCase.java
@@ -104,12 +104,10 @@ public class WalkwayUseCase {
 
     @Transactional
     public void updateWalkway(UpdateWalkwayRequest updateWalkwayRequest, Long memberId, Long walkwayId) {
-        Member member = memberQueryService.getMember(memberId);
-
         // 산책로 불러오기
         Walkway walkway = walkwayQueryService.getWalkwayWithHashtag(walkwayId);
 
-        if (!walkway.getMember().equals(member)) {
+        if (!walkway.getMember().getId().equals(memberId)) {
             throw new CustomException(WalkwayErrorCode.NOT_WALKWAY_OWNER);
         }
 

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/usecase/WalkwayUseCase.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/usecase/WalkwayUseCase.java
@@ -17,6 +17,7 @@ import com.dongsan.domains.walkway.entity.Walkway;
 import com.dongsan.domains.walkway.mapper.WalkwayMapper;
 import com.dongsan.domains.walkway.service.WalkwayCommandService;
 import com.dongsan.domains.walkway.service.WalkwayQueryService;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -74,26 +75,31 @@ public class WalkwayUseCase {
             int size
     ) {
         List<String> hashtagsList = new ArrayList<>();
-        Arrays.stream(hashtags.split(",")).forEach(hashtag -> hashtagsList.add(hashtag.trim()));
+
+        if (!hashtags.isBlank()) {
+            Arrays.stream(hashtags.split(",")).forEach(hashtag -> hashtagsList.add(hashtag.trim()));
+        }
 
         int distanceInt = (int) (distance * 1000);
 
         int likeCount = 2147483647;
         double rating = 5;
+        LocalDateTime lastCreatedAt = null;
 
         if (lastId != null) {
             Walkway walkway = walkwayQueryService.getWalkway(lastId);
             likeCount = walkway.getLikeCount();
             rating = walkway.getRating();
+            lastCreatedAt = walkway.getCreatedAt();
         }
 
         List<Walkway> walkways = switch (type) {
             case "liked" -> walkwayQueryService.getWalkwaysPopular(
-                    new SearchWalkwayPopular(userId, longitude, latitude, distanceInt, hashtagsList, lastId, likeCount,
+                    new SearchWalkwayPopular(userId, longitude, latitude, distanceInt, hashtagsList, lastCreatedAt, likeCount,
                             size)
             );
             case "rating" -> walkwayQueryService.getWalkwaysRating(
-                    new SearchWalkwayRating(userId, longitude, latitude, distanceInt, hashtagsList, lastId, rating,
+                    new SearchWalkwayRating(userId, longitude, latitude, distanceInt, hashtagsList, lastCreatedAt, rating,
                             size)
             );
             default -> throw new CustomException(WalkwayErrorCode.INVALID_SEARCH_TYPE);

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/usecase/WalkwayUseCase.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/usecase/WalkwayUseCase.java
@@ -3,8 +3,6 @@ package com.dongsan.domains.walkway.usecase;
 import com.dongsan.common.annotation.UseCase;
 import com.dongsan.common.error.code.WalkwayErrorCode;
 import com.dongsan.common.error.exception.CustomException;
-import com.dongsan.domains.hashtag.service.HashtagCommandService;
-import com.dongsan.domains.hashtag.service.HashtagQueryService;
 import com.dongsan.domains.hashtag.service.HashtagWalkwayCommandService;
 import com.dongsan.domains.member.entity.Member;
 import com.dongsan.domains.member.service.MemberQueryService;
@@ -31,8 +29,6 @@ public class WalkwayUseCase {
     private final WalkwayQueryService walkwayQueryService;
     private final MemberQueryService memberQueryService;
     private final HashtagWalkwayCommandService hashtagWalkwayCommandService;
-    private final HashtagQueryService hashtagQueryService;
-    private final HashtagCommandService hashtagCommandService;
     private final HashtagUseCase hashtagUseCase;
 
     @Transactional

--- a/app-external-api/src/main/java/com/dongsan/domains/walkway/usecase/WalkwayUseCase.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/walkway/usecase/WalkwayUseCase.java
@@ -17,7 +17,6 @@ import com.dongsan.domains.walkway.entity.Walkway;
 import com.dongsan.domains.walkway.mapper.WalkwayMapper;
 import com.dongsan.domains.walkway.service.WalkwayCommandService;
 import com.dongsan.domains.walkway.service.WalkwayQueryService;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -82,25 +81,18 @@ public class WalkwayUseCase {
 
         int distanceInt = (int) (distance * 1000);
 
-        int likeCount = 2147483647;
-        double rating = 5;
-        LocalDateTime lastCreatedAt = null;
+        Walkway lastWalkway = null;
 
         if (lastId != null) {
-            Walkway walkway = walkwayQueryService.getWalkway(lastId);
-            likeCount = walkway.getLikeCount();
-            rating = walkway.getRating();
-            lastCreatedAt = walkway.getCreatedAt();
+            lastWalkway = walkwayQueryService.getWalkway(lastId);
         }
 
         List<Walkway> walkways = switch (type) {
             case "liked" -> walkwayQueryService.getWalkwaysPopular(
-                    new SearchWalkwayPopular(userId, longitude, latitude, distanceInt, hashtagsList, lastCreatedAt, likeCount,
-                            size)
+                    new SearchWalkwayPopular(userId, longitude, latitude, distanceInt, hashtagsList, lastWalkway, size)
             );
             case "rating" -> walkwayQueryService.getWalkwaysRating(
-                    new SearchWalkwayRating(userId, longitude, latitude, distanceInt, hashtagsList, lastCreatedAt, rating,
-                            size)
+                    new SearchWalkwayRating(userId, longitude, latitude, distanceInt, hashtagsList, lastWalkway, size)
             );
             default -> throw new CustomException(WalkwayErrorCode.INVALID_SEARCH_TYPE);
         };

--- a/app-external-api/src/test/java/com/dongsan/domains/bookmark/usecase/BookmarkUseCaseTest.java
+++ b/app-external-api/src/test/java/com/dongsan/domains/bookmark/usecase/BookmarkUseCaseTest.java
@@ -227,6 +227,7 @@ class BookmarkUseCaseTest {
                 bookmarks.add(bookmark);
             }
 
+            when(walkwayQueryService.existsByWalkwayId(walkwayId)).thenReturn(true);
             when(bookmarkQueryService.getBookmarksWithMarkedWalkway(walkwayId, memberId)).thenReturn(bookmarks);
 
             // When

--- a/app-external-api/src/test/java/com/dongsan/domains/walkway/controller/WalkwayControllerTest.java
+++ b/app-external-api/src/test/java/com/dongsan/domains/walkway/controller/WalkwayControllerTest.java
@@ -142,22 +142,20 @@ class WalkwayControllerTest {
         void it_returns_DTO() throws Exception {
             // Given
             Long walkwayId = 1L;
+            Walkway walkway = WalkwayFixture.createWalkwayWithId(1L, null);
+            GetWalkwayWithLikedResponse getWalkwayWithLikedResponse = new GetWalkwayWithLikedResponse(walkway);
 
-            GetWalkwayWithLikedResponse getWalkwayWithLikedResponse = GetWalkwayWithLikedResponse.builder()
-                    .name("test")
-                    .build();
-
-            when(walkwayUseCase.getWalkwayWithLiked(walkwayId, customOAuth2User.getMemberId())).thenReturn(
-                    getWalkwayWithLikedResponse);
+            when(walkwayUseCase.getWalkwayWithLiked(walkwayId, customOAuth2User.getMemberId()))
+                    .thenReturn(walkway);
 
             // When
-            ResultActions response = mockMvc.perform(get("/walkways/1")
+            ResultActions response = mockMvc.perform(get("/walkways/" + walkwayId)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(getWalkwayWithLikedResponse)));
 
             // Then
             response.andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.name").value("test"));
+                    .andExpect(jsonPath("$.data.name").value(walkway.getName()));
         }
     }
 

--- a/app-external-api/src/test/java/com/dongsan/domains/walkway/controller/WalkwayControllerTest.java
+++ b/app-external-api/src/test/java/com/dongsan/domains/walkway/controller/WalkwayControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.dongsan.common.error.code.SystemErrorCode;
 import com.dongsan.domains.auth.security.oauth2.dto.CustomOAuth2User;
 import com.dongsan.domains.bookmark.dto.BookmarksWithMarkedWalkwayDTO;
 import com.dongsan.domains.bookmark.dto.response.BookmarksWithMarkedWalkwayResponse;
@@ -20,10 +21,8 @@ import com.dongsan.domains.walkway.dto.response.CreateWalkwayResponse;
 import com.dongsan.domains.walkway.dto.response.GetWalkwaySearchResponse;
 import com.dongsan.domains.walkway.dto.response.GetWalkwayWithLikedResponse;
 import com.dongsan.domains.walkway.entity.Walkway;
-import com.dongsan.domains.walkway.mapper.WalkwayMapper;
 import com.dongsan.domains.walkway.service.WalkwayQueryService;
 import com.dongsan.domains.walkway.usecase.WalkwayUseCase;
-import com.dongsan.common.error.code.SystemErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fixture.WalkwayFixture;
 import java.util.ArrayList;
@@ -166,16 +165,14 @@ class WalkwayControllerTest {
     @DisplayName("getWalkwaysSearch 메서드는")
     class Describe_getWalkwaysSearch {
 
-        GetWalkwaySearchResponse getWalkwaySearchResponse;
+        List<Walkway> walkways;
 
         @BeforeEach
         void setUp() {
-            List<Walkway> walkways = new ArrayList<>();
-            for (int i = 0; i < 10; i++) {
-                walkways.add(WalkwayFixture.createWalkway(member));
+            walkways = new ArrayList<>();
+            for (long i = 0; i < 10; i++) {
+                walkways.add(WalkwayFixture.createWalkwayWithId(i, member));
             }
-
-            getWalkwaySearchResponse = WalkwayMapper.toGetWalkwaySearchResponse(walkways, 10);
         }
 
         @Test
@@ -187,33 +184,28 @@ class WalkwayControllerTest {
             Double longitude = 1.0;
             Double distance = 1.3;
             String hashtags = "test";
-            Long lastId = 1L;
-            Double rating = 0.0;
-            Integer likes = 1000;
-            int size = 10;
+            Long lastId = null;
+            Integer size = 10;
 
             when(walkwayUseCase.getWalkwaysSearch(customOAuth2User.getMemberId(), type, latitude, longitude, distance,
-                    hashtags, lastId, rating,
-                    likes, size))
-                    .thenReturn(getWalkwaySearchResponse);
+                    hashtags, lastId, size))
+                    .thenReturn(walkways);
 
             // When
             ResultActions response = mockMvc.perform(get("/walkways")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .param("type", "liked")
-                    .param("hashtags", "test")
-                    .param("latitude", "1.0")
-                    .param("longitude", "1.0")
-                    .param("distance", "1.3")
-                    .param("lastId", "1")
-                    .param("likes", "1000")
-                    .param("size", "10")
-                    .content(objectMapper.writeValueAsString(getWalkwaySearchResponse)));
+                    .param("type", type)
+                    .param("hashtags", hashtags)
+                    .param("latitude", latitude.toString())
+                    .param("longitude", longitude.toString())
+                    .param("distance", distance.toString())
+                    .param("size", size.toString())
+                    .content(objectMapper.writeValueAsString(new GetWalkwaySearchResponse(walkways, size))));
             // Then
             response.andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.walkways").isArray())
                     .andExpect(jsonPath("$.data.walkways").isNotEmpty())
-                    .andExpect(jsonPath("$.data.walkways.size()").value(10));
+                    .andExpect(jsonPath("$.data.walkways.size()").value(size));
         }
 
         @Test
@@ -225,33 +217,28 @@ class WalkwayControllerTest {
             Double longitude = 1.0;
             Double distance = 1.3;
             String hashtags = "test";
-            Long lastId = 1L;
-            Double rating = 5.0;
-            Integer likes = 0;
-            int size = 10;
+            Long lastId = null;
+            Integer size = 10;
 
             when(walkwayUseCase.getWalkwaysSearch(customOAuth2User.getMemberId(), type, latitude, longitude, distance,
-                    hashtags, lastId, rating,
-                    likes, size))
-                    .thenReturn(getWalkwaySearchResponse);
+                    hashtags, lastId, size))
+                    .thenReturn(walkways);
 
             // When
             ResultActions response = mockMvc.perform(get("/walkways")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .param("type", "rating")
-                    .param("hashtags", "test")
-                    .param("latitude", "1.0")
-                    .param("longitude", "1.0")
-                    .param("distance", "1.3")
-                    .param("lastId", "1")
-                    .param("rating", "5.0")
-                    .param("size", "10")
-                    .content(objectMapper.writeValueAsString(getWalkwaySearchResponse)));
+                    .param("type", type)
+                    .param("hashtags", hashtags)
+                    .param("latitude", latitude.toString())
+                    .param("longitude", longitude.toString())
+                    .param("distance", distance.toString())
+                    .param("size", size.toString())
+                    .content(objectMapper.writeValueAsString(new GetWalkwaySearchResponse(walkways, size))));
             // Then
             response.andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.walkways").isArray())
                     .andExpect(jsonPath("$.data.walkways").isNotEmpty())
-                    .andExpect(jsonPath("$.data.walkways.size()").value(10));
+                    .andExpect(jsonPath("$.data.walkways.size()").value(size));
         }
     }
 

--- a/app-external-api/src/test/java/com/dongsan/domains/walkway/controller/WalkwayControllerTest.java
+++ b/app-external-api/src/test/java/com/dongsan/domains/walkway/controller/WalkwayControllerTest.java
@@ -22,6 +22,7 @@ import com.dongsan.domains.walkway.dto.response.GetWalkwaySearchResponse;
 import com.dongsan.domains.walkway.dto.response.GetWalkwayWithLikedResponse;
 import com.dongsan.domains.walkway.entity.Walkway;
 import com.dongsan.domains.walkway.service.WalkwayQueryService;
+import com.dongsan.domains.walkway.usecase.LikedWalkwayUseCase;
 import com.dongsan.domains.walkway.usecase.WalkwayUseCase;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fixture.WalkwayFixture;
@@ -65,6 +66,9 @@ class WalkwayControllerTest {
 
     @MockBean
     WalkwayQueryService walkwayQueryService;
+
+    @MockBean
+    LikedWalkwayUseCase likedWalkwayUseCase;
 
     final Member member = createMemberWithId(1L);
     final CustomOAuth2User customOAuth2User = new CustomOAuth2User(member);
@@ -164,12 +168,15 @@ class WalkwayControllerTest {
     class Describe_getWalkwaysSearch {
 
         List<Walkway> walkways;
+        List<Boolean> likedWalkways;
 
         @BeforeEach
         void setUp() {
             walkways = new ArrayList<>();
+            likedWalkways = new ArrayList<>();
             for (long i = 0; i < 10; i++) {
                 walkways.add(WalkwayFixture.createWalkwayWithId(i, member));
+                likedWalkways.add(true);
             }
         }
 
@@ -189,6 +196,9 @@ class WalkwayControllerTest {
                     hashtags, lastId, size))
                     .thenReturn(walkways);
 
+            when(likedWalkwayUseCase.existsLikedWalkways(customOAuth2User.getMemberId(), walkways))
+                    .thenReturn(likedWalkways);
+
             // When
             ResultActions response = mockMvc.perform(get("/walkways")
                     .contentType(MediaType.APPLICATION_JSON)
@@ -198,7 +208,7 @@ class WalkwayControllerTest {
                     .param("longitude", longitude.toString())
                     .param("distance", distance.toString())
                     .param("size", size.toString())
-                    .content(objectMapper.writeValueAsString(new GetWalkwaySearchResponse(walkways, size))));
+                    .content(objectMapper.writeValueAsString(new GetWalkwaySearchResponse(walkways, likedWalkways, size))));
             // Then
             response.andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.walkways").isArray())
@@ -222,6 +232,9 @@ class WalkwayControllerTest {
                     hashtags, lastId, size))
                     .thenReturn(walkways);
 
+            when(likedWalkwayUseCase.existsLikedWalkways(customOAuth2User.getMemberId(), walkways))
+                    .thenReturn(likedWalkways);
+
             // When
             ResultActions response = mockMvc.perform(get("/walkways")
                     .contentType(MediaType.APPLICATION_JSON)
@@ -231,7 +244,7 @@ class WalkwayControllerTest {
                     .param("longitude", longitude.toString())
                     .param("distance", distance.toString())
                     .param("size", size.toString())
-                    .content(objectMapper.writeValueAsString(new GetWalkwaySearchResponse(walkways, size))));
+                    .content(objectMapper.writeValueAsString(new GetWalkwaySearchResponse(walkways, likedWalkways, size))));
             // Then
             response.andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.walkways").isArray())

--- a/app-external-api/src/test/java/com/dongsan/domains/walkway/usecase/LikedWalkwayUseCaseTest.java
+++ b/app-external-api/src/test/java/com/dongsan/domains/walkway/usecase/LikedWalkwayUseCaseTest.java
@@ -1,5 +1,6 @@
 package com.dongsan.domains.walkway.usecase;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -8,9 +9,12 @@ import com.dongsan.domains.member.entity.Member;
 import com.dongsan.domains.member.service.MemberQueryService;
 import com.dongsan.domains.walkway.entity.Walkway;
 import com.dongsan.domains.walkway.service.LikedWalkwayCommandService;
+import com.dongsan.domains.walkway.service.LikedWalkwayQueryService;
 import com.dongsan.domains.walkway.service.WalkwayQueryService;
 import fixture.MemberFixture;
 import fixture.WalkwayFixture;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -28,6 +32,8 @@ class LikedWalkwayUseCaseTest {
     MemberQueryService memberQueryService;
     @Mock
     WalkwayQueryService walkwayQueryService;
+    @Mock
+    LikedWalkwayQueryService likedWalkwayQueryService;
     @InjectMocks
     LikedWalkwayUseCase likedWalkwayUseCase;
 
@@ -72,6 +78,35 @@ class LikedWalkwayUseCaseTest {
 
             // Then
             verify(likedWalkwayCommandService).deleteLikedWalkway(member, walkway);
+        }
+    }
+
+    @Nested
+    @DisplayName("existsLikedWalkways 메서드는")
+    class Describe_existsLikedWalkways {
+        @Test
+        @DisplayName("회원의 산책로 좋아요 여부 리스트를 반환한다..")
+        void it_returns_liked_exists_list() {
+            // Given
+            Member member = MemberFixture.createMemberWithId(1L);
+            List<Walkway> walkways = new ArrayList<>();
+            for (long id = 0; id < 10; id++) {
+                walkways.add(WalkwayFixture.createWalkwayWithId(id, member));
+            }
+
+            for (long id = 0; id < 10; id++) {
+                when(likedWalkwayQueryService.existByMemberIdAndWalkwayId(member.getId(), id)).thenReturn(true);
+            }
+
+            // When
+            List<Boolean> result = likedWalkwayUseCase.existsLikedWalkways(member.getId(), walkways);
+
+            // Then
+            assertThat(result).hasSize(10);
+            for (int index = 0; index < result.size(); index++) {
+                assertThat(result.get(index)).isTrue();
+            }
+
         }
     }
 }

--- a/app-external-api/src/test/java/com/dongsan/domains/walkway/usecase/WalkwayReviewUseCaseTest.java
+++ b/app-external-api/src/test/java/com/dongsan/domains/walkway/usecase/WalkwayReviewUseCaseTest.java
@@ -97,6 +97,7 @@ class WalkwayReviewUseCaseTest {
                 reviews.add(createReviewWithId(1L, member, walkway));
             }
 
+            when(walkwayQueryService.existsByWalkwayId(walkwayId)).thenReturn(true);
             when(reviewQueryService.getWalkwayReviewsRating(size, null, walkwayId, rating)).thenReturn(reviews);
 
             // When
@@ -122,6 +123,7 @@ class WalkwayReviewUseCaseTest {
                 reviews.add(createReviewWithId(1L, member, walkway));
             }
 
+            when(walkwayQueryService.existsByWalkwayId(walkwayId)).thenReturn(true);
             when(reviewQueryService.getWalkwayReviewsLatest(size, null, walkwayId)).thenReturn(reviews);
 
             // When

--- a/app-external-api/src/test/java/com/dongsan/domains/walkway/usecase/WalkwayReviewUseCaseTest.java
+++ b/app-external-api/src/test/java/com/dongsan/domains/walkway/usecase/WalkwayReviewUseCaseTest.java
@@ -69,6 +69,7 @@ class WalkwayReviewUseCaseTest {
             when(memberQueryService.getMember(member.getId())).thenReturn(member);
             when(walkwayQueryService.getWalkway(walkway.getId())).thenReturn(walkway);
             when(reviewCommandService.createReview(any())).thenReturn(review);
+            when(reviewQueryService.getWalkwayReviewCount(walkwayId)).thenReturn(1);
 
             // When
             CreateReviewResponse result = walkwayReviewUseCase.createReview(memberId, walkwayId, createReviewRequest);

--- a/app-external-api/src/test/java/com/dongsan/domains/walkway/usecase/WalkwayUseCaseTest.java
+++ b/app-external-api/src/test/java/com/dongsan/domains/walkway/usecase/WalkwayUseCaseTest.java
@@ -232,12 +232,11 @@ class WalkwayUseCaseTest {
         void it_returns_exceptions() {
             // Given
             Long memberId = 1L;
+            Long otherMemberId = 2L;
             Long walkwayId = 1L;
-            Member member = MemberFixture.createMemberWithId(memberId);
-            Member otherMember = MemberFixture.createMember();
+            Member otherMember = MemberFixture.createMemberWithId(otherMemberId);
             Walkway walkway = WalkwayFixture.createWalkwayWithId(walkwayId, otherMember);
 
-            when(memberQueryService.getMember(member.getId())).thenReturn(member);
             when(walkwayQueryService.getWalkwayWithHashtag(walkway.getId())).thenReturn(walkway);
 
             // When & Then
@@ -250,7 +249,7 @@ class WalkwayUseCaseTest {
         @DisplayName("산책로를 수정한다.")
         void it_update_walkway() {
             // Given
-            Member member = MemberFixture.createMember();
+            Member member = MemberFixture.createMemberWithId(1L);
             Long walkwayId = 1L;
             Walkway walkway = WalkwayFixture.createWalkwayWithId(walkwayId, member);
             UpdateWalkwayRequest updateWalkwayRequest = new UpdateWalkwayRequest(
@@ -259,7 +258,6 @@ class WalkwayUseCaseTest {
                     List.of(),
                     "비공개");
 
-            when(memberQueryService.getMember(member.getId())).thenReturn(member);
             when(walkwayQueryService.getWalkwayWithHashtag(walkway.getId())).thenReturn(walkway);
             when(walkwayCommandService.createWalkway(walkway)).thenReturn(null);
 

--- a/app-external-api/src/test/java/com/dongsan/domains/walkway/usecase/WalkwayUseCaseTest.java
+++ b/app-external-api/src/test/java/com/dongsan/domains/walkway/usecase/WalkwayUseCaseTest.java
@@ -22,7 +22,6 @@ import com.dongsan.domains.walkway.service.WalkwayCommandService;
 import com.dongsan.domains.walkway.service.WalkwayQueryService;
 import fixture.MemberFixture;
 import fixture.WalkwayFixture;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -148,8 +147,7 @@ class WalkwayUseCaseTest {
             Double distance = 10.0;
             String hashtags = "test0,test1";
             Long lastId = null;
-            LocalDateTime createdAt = null;
-            Integer lastLikes = 2147483647;
+            Walkway lastWalkway = null;
             int size = 10;
 
             List<String> hashtagsList = new ArrayList<>();
@@ -158,7 +156,7 @@ class WalkwayUseCaseTest {
             int distanceInt = (int) (distance * 1000);
 
             SearchWalkwayPopular searchWalkwayPopular
-                    = new SearchWalkwayPopular(userId, longitude, latitude, distanceInt, hashtagsList, createdAt, lastLikes, size);
+                    = new SearchWalkwayPopular(userId, longitude, latitude, distanceInt, hashtagsList, lastWalkway, size);
 
             when(walkwayQueryService.getWalkwaysPopular(searchWalkwayPopular))
                     .thenReturn(walkways);
@@ -183,8 +181,7 @@ class WalkwayUseCaseTest {
             Double distance = 10.0;
             String hashtags = "test0,test1";
             Long lastId = null;
-            LocalDateTime createdAt = null;
-            Double lastRating = 5.0;
+            Walkway lastWalkway = null;
             int size = 10;
 
             List<String> hashtagsList = new ArrayList<>();
@@ -192,7 +189,7 @@ class WalkwayUseCaseTest {
 
             int distanceInt = (int) (distance * 1000);
 
-            SearchWalkwayRating searchWalkwayRating = new SearchWalkwayRating(userId, longitude, latitude, distanceInt, hashtagsList, createdAt, lastRating, size);
+            SearchWalkwayRating searchWalkwayRating = new SearchWalkwayRating(userId, longitude, latitude, distanceInt, hashtagsList, lastWalkway, size);
             when(walkwayQueryService.getWalkwaysRating(searchWalkwayRating))
                     .thenReturn(walkways);
 

--- a/app-external-api/src/test/java/com/dongsan/domains/walkway/usecase/WalkwayUseCaseTest.java
+++ b/app-external-api/src/test/java/com/dongsan/domains/walkway/usecase/WalkwayUseCaseTest.java
@@ -22,6 +22,7 @@ import com.dongsan.domains.walkway.service.WalkwayCommandService;
 import com.dongsan.domains.walkway.service.WalkwayQueryService;
 import fixture.MemberFixture;
 import fixture.WalkwayFixture;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -147,6 +148,7 @@ class WalkwayUseCaseTest {
             Double distance = 10.0;
             String hashtags = "test0,test1";
             Long lastId = null;
+            LocalDateTime createdAt = null;
             Integer lastLikes = 2147483647;
             int size = 10;
 
@@ -156,7 +158,7 @@ class WalkwayUseCaseTest {
             int distanceInt = (int) (distance * 1000);
 
             SearchWalkwayPopular searchWalkwayPopular
-                    = new SearchWalkwayPopular(userId, longitude, latitude, distanceInt, hashtagsList, lastId, lastLikes, size);
+                    = new SearchWalkwayPopular(userId, longitude, latitude, distanceInt, hashtagsList, createdAt, lastLikes, size);
 
             when(walkwayQueryService.getWalkwaysPopular(searchWalkwayPopular))
                     .thenReturn(walkways);
@@ -181,6 +183,7 @@ class WalkwayUseCaseTest {
             Double distance = 10.0;
             String hashtags = "test0,test1";
             Long lastId = null;
+            LocalDateTime createdAt = null;
             Double lastRating = 5.0;
             int size = 10;
 
@@ -189,7 +192,7 @@ class WalkwayUseCaseTest {
 
             int distanceInt = (int) (distance * 1000);
 
-            SearchWalkwayRating searchWalkwayRating = new SearchWalkwayRating(userId, longitude, latitude, distanceInt, hashtagsList, lastId, lastRating, size);
+            SearchWalkwayRating searchWalkwayRating = new SearchWalkwayRating(userId, longitude, latitude, distanceInt, hashtagsList, createdAt, lastRating, size);
             when(walkwayQueryService.getWalkwaysRating(searchWalkwayRating))
                     .thenReturn(walkways);
 

--- a/app-external-api/src/test/java/com/dongsan/domains/walkway/usecase/WalkwayUseCaseTest.java
+++ b/app-external-api/src/test/java/com/dongsan/domains/walkway/usecase/WalkwayUseCaseTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import com.dongsan.common.error.exception.CustomException;
 import com.dongsan.domains.hashtag.service.HashtagQueryService;
 import com.dongsan.domains.hashtag.service.HashtagWalkwayCommandService;
 import com.dongsan.domains.member.entity.Member;
@@ -15,17 +16,16 @@ import com.dongsan.domains.walkway.dto.SearchWalkwayRating;
 import com.dongsan.domains.walkway.dto.request.CreateWalkwayRequest;
 import com.dongsan.domains.walkway.dto.request.UpdateWalkwayRequest;
 import com.dongsan.domains.walkway.dto.response.CreateWalkwayResponse;
-import com.dongsan.domains.walkway.dto.response.GetWalkwaySearchResponse;
 import com.dongsan.domains.walkway.dto.response.GetWalkwayWithLikedResponse;
 import com.dongsan.domains.walkway.entity.Walkway;
 import com.dongsan.domains.walkway.enums.ExposeLevel;
 import com.dongsan.domains.walkway.mapper.WalkwayMapper;
 import com.dongsan.domains.walkway.service.WalkwayCommandService;
 import com.dongsan.domains.walkway.service.WalkwayQueryService;
-import com.dongsan.common.error.exception.CustomException;
 import fixture.MemberFixture;
 import fixture.WalkwayFixture;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -151,12 +151,12 @@ class WalkwayUseCaseTest {
             Double longitude = 2.0;
             Double distance = 10.0;
             String hashtags = "test0,test1";
-            Long lastId = 0L;
-            Double lastRating = null;
-            Integer lastLikes = 1000;
+            Long lastId = null;
+            Integer lastLikes = 2147483647;
             int size = 10;
 
-            List<String> hashtagsList = List.of(hashtags.split(","));
+            List<String> hashtagsList = new ArrayList<>();
+            Arrays.stream(hashtags.split(",")).forEach(hashtag -> hashtagsList.add(hashtag.trim()));
 
             int distanceInt = (int) (distance * 1000);
 
@@ -167,12 +167,12 @@ class WalkwayUseCaseTest {
                     .thenReturn(walkways);
 
             // when
-            GetWalkwaySearchResponse result
-                    = walkwayUseCase.getWalkwaysSearch(userId, type, latitude, longitude, distance, hashtags, lastId, lastRating, lastLikes, size);
+            List<Walkway> result
+                    = walkwayUseCase.getWalkwaysSearch(userId, type, latitude, longitude, distance, hashtags, lastId, size);
 
             // then
-            assertThat(result.nextCursor()).isNotNull();
-            assertThat(result.walkways().size()).isEqualTo(10);
+            assertThat(result).isNotNull();
+            assertThat(result).hasSize(size);
         }
 
         @Test
@@ -185,12 +185,12 @@ class WalkwayUseCaseTest {
             Double longitude = 2.0;
             Double distance = 10.0;
             String hashtags = "test0,test1";
-            Long lastId = 0L;
+            Long lastId = null;
             Double lastRating = 5.0;
-            Integer lastLikes = null;
             int size = 10;
 
-            List<String> hashtagsList = List.of(hashtags.split(","));
+            List<String> hashtagsList = new ArrayList<>();
+            Arrays.stream(hashtags.split(",")).forEach(hashtag -> hashtagsList.add(hashtag.trim()));
 
             int distanceInt = (int) (distance * 1000);
 
@@ -199,13 +199,13 @@ class WalkwayUseCaseTest {
                     .thenReturn(walkways);
 
             // when
-            GetWalkwaySearchResponse result
+            List<Walkway> result
                     = walkwayUseCase.getWalkwaysSearch(userId, type, latitude, longitude, distance, hashtags, lastId,
-                    lastRating, lastLikes, size);
+                    size);
 
             // then
-            assertThat(result.nextCursor()).isNotNull();
-            assertThat(result.walkways().size()).isEqualTo(10);
+            assertThat(result).isNotNull();
+            assertThat(result).hasSize(10);
         }
 
         @Test
@@ -218,14 +218,12 @@ class WalkwayUseCaseTest {
             Double longitude = 2.0;
             Double distance = 10.0;
             String hashtags = "test0,test1";
-            Long lastId = 0L;
-            Double lastRating = 5.0;
-            Integer lastLikes = null;
+            Long lastId = null;
             int size = 10;
 
             assertThatThrownBy(
                     () -> walkwayUseCase.getWalkwaysSearch(userId, type, latitude, longitude, distance, hashtags,
-                            lastId, lastRating, lastLikes, size))
+                            lastId, size))
                     .isInstanceOf(CustomException.class);
         }
 

--- a/app-external-api/src/test/java/com/dongsan/domains/walkway/usecase/WalkwayUseCaseTest.java
+++ b/app-external-api/src/test/java/com/dongsan/domains/walkway/usecase/WalkwayUseCaseTest.java
@@ -16,10 +16,8 @@ import com.dongsan.domains.walkway.dto.SearchWalkwayRating;
 import com.dongsan.domains.walkway.dto.request.CreateWalkwayRequest;
 import com.dongsan.domains.walkway.dto.request.UpdateWalkwayRequest;
 import com.dongsan.domains.walkway.dto.response.CreateWalkwayResponse;
-import com.dongsan.domains.walkway.dto.response.GetWalkwayWithLikedResponse;
 import com.dongsan.domains.walkway.entity.Walkway;
 import com.dongsan.domains.walkway.enums.ExposeLevel;
-import com.dongsan.domains.walkway.mapper.WalkwayMapper;
 import com.dongsan.domains.walkway.service.WalkwayCommandService;
 import com.dongsan.domains.walkway.service.WalkwayQueryService;
 import fixture.MemberFixture;
@@ -116,14 +114,11 @@ class WalkwayUseCaseTest {
 
             when(walkwayQueryService.getWalkwayWithHashtagAndLike(any(), any())).thenReturn(walkway);
 
-            GetWalkwayWithLikedResponse getWalkwayWithLikedResponse
-                    = WalkwayMapper.toGetWalkwayWithLikedResponse(walkway);
-
             // when
-            GetWalkwayWithLikedResponse result = walkwayUseCase.getWalkwayWithLiked(walkway.getId(), member.getId());
+            Walkway result = walkwayUseCase.getWalkwayWithLiked(walkway.getId(), member.getId());
 
             // then
-            assertThat(result).isEqualTo(getWalkwayWithLikedResponse);
+            assertThat(result).isEqualTo(walkway);
         }
     }
 

--- a/domain/domain-rdb/src/main/java/com/dongsan/domains/review/repository/ReviewRepository.java
+++ b/domain/domain-rdb/src/main/java/com/dongsan/domains/review/repository/ReviewRepository.java
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long>{
     boolean existsByIdAndMemberId(Long reviewId, Long memberId);
+
+    Integer countByWalkwayId(Long walkwayId);
 }

--- a/domain/domain-rdb/src/main/java/com/dongsan/domains/review/service/ReviewQueryService.java
+++ b/domain/domain-rdb/src/main/java/com/dongsan/domains/review/service/ReviewQueryService.java
@@ -49,4 +49,8 @@ public class ReviewQueryService {
             throw new CustomException(ReviewErrorCode.NOT_REVIEW_OWNER);
         }
     }
+
+    public Integer getWalkwayReviewCount(Long walkwayId) {
+        return reviewRepository.countByWalkwayId(walkwayId);
+    }
 }

--- a/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/dto/SearchWalkwayPopular.java
+++ b/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/dto/SearchWalkwayPopular.java
@@ -1,5 +1,6 @@
 package com.dongsan.domains.walkway.dto;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record SearchWalkwayPopular(
@@ -8,7 +9,7 @@ public record SearchWalkwayPopular(
         Double latitude,
         int distance,
         List<String> hashtags,
-        Long lastId,
+        LocalDateTime createdAt,
         Integer lastLikes,
         int size
 ) {

--- a/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/dto/SearchWalkwayPopular.java
+++ b/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/dto/SearchWalkwayPopular.java
@@ -1,6 +1,6 @@
 package com.dongsan.domains.walkway.dto;
 
-import java.time.LocalDateTime;
+import com.dongsan.domains.walkway.entity.Walkway;
 import java.util.List;
 
 public record SearchWalkwayPopular(
@@ -9,8 +9,7 @@ public record SearchWalkwayPopular(
         Double latitude,
         int distance,
         List<String> hashtags,
-        LocalDateTime createdAt,
-        Integer lastLikes,
+        Walkway walkway,
         int size
 ) {
 }

--- a/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/dto/SearchWalkwayRating.java
+++ b/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/dto/SearchWalkwayRating.java
@@ -1,6 +1,6 @@
 package com.dongsan.domains.walkway.dto;
 
-import java.time.LocalDateTime;
+import com.dongsan.domains.walkway.entity.Walkway;
 import java.util.List;
 
 public record SearchWalkwayRating(
@@ -9,8 +9,9 @@ public record SearchWalkwayRating(
         Double latitude,
         int distance,
         List<String> hashtags,
-        LocalDateTime createdAt,
-        Double lastRating,
+//        LocalDateTime createdAt,
+//        Double lastRating,
+        Walkway walkway,
         int size
 ) {
 }

--- a/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/dto/SearchWalkwayRating.java
+++ b/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/dto/SearchWalkwayRating.java
@@ -1,5 +1,6 @@
 package com.dongsan.domains.walkway.dto;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record SearchWalkwayRating(
@@ -8,7 +9,7 @@ public record SearchWalkwayRating(
         Double latitude,
         int distance,
         List<String> hashtags,
-        Long lastId,
+        LocalDateTime createdAt,
         Double lastRating,
         int size
 ) {

--- a/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/entity/Walkway.java
+++ b/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/entity/Walkway.java
@@ -91,8 +91,8 @@ public class Walkway extends BaseEntity {
         this.rating = 0.0;
     }
 
-    public void updateRatingAndReviewCount(Byte inputRating) {
-        this.rating = (this.rating + inputRating) / 2;
+    public void updateRatingAndReviewCount(Byte inputRating, Integer count) {
+        this.rating = ((this.rating * count) + inputRating) / (count + 1);
         this.reviewCount++;
     }
 
@@ -104,7 +104,7 @@ public class Walkway extends BaseEntity {
         this.likeCount++;
     }
     public void removeLikedWalkway() {
-        this.likeCount++;
+        this.likeCount--;
     }
     public void removeAllHashtagWalkway() {
         this.hashtagWalkways = new ArrayList<>();

--- a/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/repository/LikedWalkwayRepository.java
+++ b/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/repository/LikedWalkwayRepository.java
@@ -14,4 +14,6 @@ public interface LikedWalkwayRepository extends JpaRepository<LikedWalkway, Long
     Boolean existsByMemberAndWalkway(Member member, Walkway walkway);
 
     void deleteByMemberAndWalkway(Member member, Walkway walkway);
+
+    Boolean existsByMemberIdAndWalkwayId(Long memberId, Long walkwayId);
 }

--- a/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/repository/WalkwayQueryDSLRepository.java
+++ b/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/repository/WalkwayQueryDSLRepository.java
@@ -49,8 +49,6 @@ public class WalkwayQueryDSLRepository {
                 .fetchJoin()
                 .join(hashtagWalkway.hashtag, hashtag)
                 .fetchJoin()
-                .leftJoin(walkway.likedWalkways, likedWalkway)
-                .on(likedWalkway.member.id.eq(searchWalkwayPopular.userId()))
                 .where(
                         Expressions.booleanTemplate(
                                 "ST_Distance_Sphere({0}," + point + ") <= {1}",
@@ -86,8 +84,6 @@ public class WalkwayQueryDSLRepository {
                 .fetchJoin()
                 .join(hashtagWalkway.hashtag, hashtag)
                 .fetchJoin()
-                .leftJoin(walkway.likedWalkways, likedWalkway)
-                .on(likedWalkway.member.id.eq(searchWalkwayRating.userId()))
                 .where(
                         Expressions.booleanTemplate(
                                 "ST_Distance_Sphere({0}," + point + ") <= {1}",

--- a/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/repository/WalkwayQueryDSLRepository.java
+++ b/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/repository/WalkwayQueryDSLRepository.java
@@ -13,6 +13,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -112,8 +113,8 @@ public class WalkwayQueryDSLRepository {
         return createdAt != null ? walkway.createdAt.lt(createdAt) : null;
     }
 
-    public Walkway getWalkwayWithHashtag(Long walkwayId) {
-        return queryFactory.selectFrom(walkway)
+    public Optional<Walkway> getWalkwayWithHashtag(Long walkwayId) {
+        return Optional.ofNullable(queryFactory.selectFrom(walkway)
                 .join(walkway.hashtagWalkways, hashtagWalkway)
                 .fetchJoin()
                 .join(hashtagWalkway.hashtag)
@@ -121,7 +122,7 @@ public class WalkwayQueryDSLRepository {
                 .join(walkway.member)
                 .fetchJoin()
                 .where(walkway.id.eq(walkwayId))
-                .fetchOne();
+                .fetchOne());
     }
 
 }

--- a/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/repository/WalkwayQueryDSLRepository.java
+++ b/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/repository/WalkwayQueryDSLRepository.java
@@ -66,9 +66,7 @@ public class WalkwayQueryDSLRepository {
                                         .on(hashtagWalkway.hashtag.eq(hashtag))
                                         .where(walkwayHashtagIn(searchWalkwayPopular.hashtags()))
                         ),
-                        walkway.likeCount.eq(searchWalkwayPopular.lastLikes())
-                                .or(createdAtLt(searchWalkwayPopular.createdAt()))
-                                .or(walkway.likeCount.lt(searchWalkwayPopular.lastLikes())),
+                        walkwaySearchLikeEqLt(searchWalkwayPopular.walkway()),
                         walkway.exposeLevel.eq(ExposeLevel.PUBLIC)
                 )
                 .orderBy(walkway.likeCount.desc(), walkway.createdAt.desc())
@@ -105,9 +103,7 @@ public class WalkwayQueryDSLRepository {
                                         .on(hashtagWalkway.hashtag.eq(hashtag))
                                         .where(walkwayHashtagIn(searchWalkwayRating.hashtags()))
                         ),
-                        walkway.rating.eq(searchWalkwayRating.lastRating())
-                                .or(createdAtLt(searchWalkwayRating.createdAt()))
-                                .or(walkway.rating.lt(searchWalkwayRating.lastRating())),
+                        walkwaySearchRatingEqLt(searchWalkwayRating.walkway()),
                         walkway.exposeLevel.eq(ExposeLevel.PUBLIC)
                 )
                 .orderBy(walkway.rating.desc(), walkway.createdAt.desc())
@@ -157,6 +153,24 @@ public class WalkwayQueryDSLRepository {
 
     private BooleanExpression walkwayHashtagIn(List<String> hashtags) {
         return hashtags.isEmpty() ? null : hashtag.name.in(hashtags);
+    }
+
+    private BooleanExpression walkwaySearchRatingEqLt(Walkway lastWalkway) {
+        if (lastWalkway == null) {
+            return null;
+        }
+        return walkway.createdAt.lt(lastWalkway.getCreatedAt())
+                .or(walkway.rating.eq(lastWalkway.getRating()))
+                .or(walkway.rating.lt(lastWalkway.getRating()));
+    }
+
+    private BooleanExpression walkwaySearchLikeEqLt(Walkway lastWalkway) {
+        if (lastWalkway == null) {
+            return null;
+        }
+        return walkway.createdAt.lt(lastWalkway.getCreatedAt())
+                .or(walkway.likeCount.eq(lastWalkway.getLikeCount()))
+                .or(walkway.likeCount.lt(lastWalkway.getLikeCount()));
     }
 
 }

--- a/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/repository/WalkwayQueryDSLRepository.java
+++ b/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/repository/WalkwayQueryDSLRepository.java
@@ -64,7 +64,10 @@ public class WalkwayQueryDSLRepository {
                                         .on(hashtagWalkway.hashtag.eq(hashtag))
                                         .where(walkwayHashtagIn(searchWalkwayPopular.hashtags()))
                         ),
-                        walkwaySearchLikeEqLt(searchWalkwayPopular.walkway()),
+                        searchWalkwayPopular.walkway() == null
+                                ? null
+                                : likeCountEqLt(searchWalkwayPopular.walkway().getLikeCount())
+                                        .or(createdAtLt(searchWalkwayPopular.walkway().getCreatedAt())),
                         walkway.exposeLevel.eq(ExposeLevel.PUBLIC)
                 )
                 .orderBy(walkway.likeCount.desc(), walkway.createdAt.desc())
@@ -99,7 +102,10 @@ public class WalkwayQueryDSLRepository {
                                         .on(hashtagWalkway.hashtag.eq(hashtag))
                                         .where(walkwayHashtagIn(searchWalkwayRating.hashtags()))
                         ),
-                        walkwaySearchRatingEqLt(searchWalkwayRating.walkway()),
+                        searchWalkwayRating.walkway() == null
+                                ? null
+                                : ratingEqLt(searchWalkwayRating.walkway().getRating())
+                                        .or(createdAtLt(searchWalkwayRating.walkway().getCreatedAt())),
                         walkway.exposeLevel.eq(ExposeLevel.PUBLIC)
                 )
                 .orderBy(walkway.rating.desc(), walkway.createdAt.desc())
@@ -151,22 +157,12 @@ public class WalkwayQueryDSLRepository {
         return hashtags.isEmpty() ? null : hashtag.name.in(hashtags);
     }
 
-    private BooleanExpression walkwaySearchRatingEqLt(Walkway lastWalkway) {
-        if (lastWalkway == null) {
-            return null;
-        }
-        return walkway.createdAt.lt(lastWalkway.getCreatedAt())
-                .or(walkway.rating.eq(lastWalkway.getRating()))
-                .or(walkway.rating.lt(lastWalkway.getRating()));
+    private BooleanExpression ratingEqLt(Double rating) {
+        return rating == null ? null : walkway.rating.loe(rating);
     }
 
-    private BooleanExpression walkwaySearchLikeEqLt(Walkway lastWalkway) {
-        if (lastWalkway == null) {
-            return null;
-        }
-        return walkway.createdAt.lt(lastWalkway.getCreatedAt())
-                .or(walkway.likeCount.eq(lastWalkway.getLikeCount()))
-                .or(walkway.likeCount.lt(lastWalkway.getLikeCount()));
+    private BooleanExpression likeCountEqLt(Integer likeCount) {
+        return likeCount == null ? null : walkway.likeCount.loe(likeCount);
     }
 
 }

--- a/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/service/LikedWalkwayQueryService.java
+++ b/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/service/LikedWalkwayQueryService.java
@@ -33,4 +33,8 @@ public class LikedWalkwayQueryService {
                         () -> new CustomException(LikedWalkwayErrorCode.LIKED_WALKWAY_NOT_FOUND));
     }
 
+    public Boolean existByMemberIdAndWalkwayId(Long memberId, Long walkwayId) {
+        return likedWalkwayRepository.existsByMemberIdAndWalkwayId(memberId, walkwayId);
+    }
+
 }

--- a/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/service/WalkwayQueryService.java
+++ b/domain/domain-rdb/src/main/java/com/dongsan/domains/walkway/service/WalkwayQueryService.java
@@ -55,7 +55,8 @@ public class WalkwayQueryService {
     }
 
     public Walkway getWalkwayWithHashtag(Long walkwayId) {
-        return walkwayQueryDSLRepository.getWalkwayWithHashtag(walkwayId);
+        return walkwayQueryDSLRepository.getWalkwayWithHashtag(walkwayId)
+                .orElseThrow(() -> new CustomException(WalkwayErrorCode.WALKWAY_NOT_FOUND));
     }
 
     public List<Walkway> getBookmarkWalkway(Bookmark bookmark, Integer size, LocalDateTime lastCreatedAt) {

--- a/domain/domain-rdb/src/test/java/com/dongsan/domains/walkway/repository/WalkwayQueryDSLRepositoryTest.java
+++ b/domain/domain-rdb/src/test/java/com/dongsan/domains/walkway/repository/WalkwayQueryDSLRepositoryTest.java
@@ -15,6 +15,7 @@ import fixture.MemberFixture;
 import fixture.WalkwayFixture;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -155,12 +156,13 @@ class WalkwayQueryDSLRepositoryTest extends RepositoryTest {
             em.persist(hashtagWalkway);
 
             // When
-            Walkway result = walkwayQueryDSLRepository.getWalkwayWithHashtag(walkway.getId());
+            Optional<Walkway> result = walkwayQueryDSLRepository.getWalkwayWithHashtag(walkway.getId());
 
             // Then
-            assertThat(result.getId()).isEqualTo(walkway.getId());
-            assertThat(result.getMember()).isEqualTo(member);
-            assertThat(result.getHashtagWalkways()).hasSize(4);
+            assertThat(result.isPresent()).isTrue();
+            assertThat(result.get().getId()).isEqualTo(walkway.getId());
+            assertThat(result.get().getMember()).isEqualTo(member);
+            assertThat(result.get().getHashtagWalkways()).hasSize(4);
         }
     }
 }

--- a/domain/domain-rdb/src/test/java/com/dongsan/domains/walkway/service/LikedWalkwayQueryServiceTest.java
+++ b/domain/domain-rdb/src/test/java/com/dongsan/domains/walkway/service/LikedWalkwayQueryServiceTest.java
@@ -8,11 +8,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
+import com.dongsan.common.error.code.LikedWalkwayErrorCode;
+import com.dongsan.common.error.exception.CustomException;
 import com.dongsan.domains.walkway.entity.LikedWalkway;
 import com.dongsan.domains.walkway.repository.LikedWalkwayQueryDSLRepository;
 import com.dongsan.domains.walkway.repository.LikedWalkwayRepository;
-import com.dongsan.common.error.code.LikedWalkwayErrorCode;
-import com.dongsan.common.error.exception.CustomException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -118,6 +118,26 @@ class LikedWalkwayQueryServiceTest {
                 likedWalkwayQueryService.findByMemberIdAndWalkwayId(memberId, walkwayId);
             });
             assertEquals(LikedWalkwayErrorCode.LIKED_WALKWAY_NOT_FOUND, thrown.getErrorCode());
+        }
+    }
+
+    @Nested
+    @DisplayName("existByMemberIdAndWalkwayId 메서드는")
+    class Describe_existByMemberIdAndWalkwayId {
+        @Test
+        @DisplayName("MemberId와 WalkwayId로 LikedWalkway의 유무를 반환한다.")
+        void it_returns_exists() {
+            // Given
+            Long memberId = 1L;
+            Long walkwayId = 1L;
+
+            when(likedWalkwayRepository.existsByMemberIdAndWalkwayId(memberId, walkwayId)).thenReturn(true);
+
+            // When
+            Boolean result = likedWalkwayQueryService.existByMemberIdAndWalkwayId(memberId, walkwayId);
+
+            // Then
+            assertThat(result).isTrue();
         }
     }
 }

--- a/domain/domain-rdb/src/test/java/com/dongsan/domains/walkway/service/WalkwayQueryServiceTest.java
+++ b/domain/domain-rdb/src/test/java/com/dongsan/domains/walkway/service/WalkwayQueryServiceTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
+import com.dongsan.common.error.exception.CustomException;
 import com.dongsan.domains.bookmark.entity.Bookmark;
 import com.dongsan.domains.bookmark.entity.MarkedWalkway;
 import com.dongsan.domains.bookmark.repository.MarkedWalkwayQueryDSLRepository;
@@ -17,7 +18,6 @@ import com.dongsan.domains.walkway.dto.SearchWalkwayRating;
 import com.dongsan.domains.walkway.entity.Walkway;
 import com.dongsan.domains.walkway.repository.WalkwayQueryDSLRepository;
 import com.dongsan.domains.walkway.repository.WalkwayRepository;
-import com.dongsan.common.error.exception.CustomException;
 import fixture.MarkedWalkwayFixture;
 import fixture.MemberFixture;
 import fixture.WalkwayFixture;
@@ -186,12 +186,12 @@ class WalkwayQueryServiceTest {
             Double latitude = 2.0;
             int distance = 3;
             List<String> hashtags = new ArrayList<>();
-            Long lastId = 1L;
+            LocalDateTime createdAt = LocalDateTime.now();
             Integer lastLikes = 20;
             int size = 10;
 
             SearchWalkwayPopular searchWalkwayPopular
-                    = new SearchWalkwayPopular(userId, longitude, latitude, distance, hashtags, lastId, lastLikes,
+                    = new SearchWalkwayPopular(userId, longitude, latitude, distance, hashtags, createdAt, lastLikes,
                     size);
 
             List<Walkway> walkways = new ArrayList<>();
@@ -221,12 +221,12 @@ class WalkwayQueryServiceTest {
             Double latitude = 2.0;
             int distance = 3;
             List<String> hashtags = new ArrayList<>();
-            Long lastId = 1L;
+            LocalDateTime createdAt = LocalDateTime.now();
             Double lastRating = 5.0;
             int size = 10;
 
             SearchWalkwayRating searchWalkwayRating
-                    = new SearchWalkwayRating(userId, longitude, latitude, distance, hashtags, lastId, lastRating,
+                    = new SearchWalkwayRating(userId, longitude, latitude, distance, hashtags, createdAt, lastRating,
                     size);
 
             List<Walkway> walkways = new ArrayList<>();

--- a/domain/domain-rdb/src/test/java/com/dongsan/domains/walkway/service/WalkwayQueryServiceTest.java
+++ b/domain/domain-rdb/src/test/java/com/dongsan/domains/walkway/service/WalkwayQueryServiceTest.java
@@ -252,7 +252,7 @@ class WalkwayQueryServiceTest {
         void it_returns_walkway() {
             // Given
             Walkway walkway = WalkwayFixture.createWalkway(null);
-            when(walkwayQueryDSLRepository.getWalkwayWithHashtag(walkway.getId())).thenReturn(walkway);
+            when(walkwayQueryDSLRepository.getWalkwayWithHashtag(walkway.getId())).thenReturn(Optional.of(walkway));
 
             // When
             Walkway result = walkwayQueryService.getWalkwayWithHashtag(walkway.getId());

--- a/domain/domain-rdb/src/test/java/com/dongsan/domains/walkway/service/WalkwayQueryServiceTest.java
+++ b/domain/domain-rdb/src/test/java/com/dongsan/domains/walkway/service/WalkwayQueryServiceTest.java
@@ -186,13 +186,11 @@ class WalkwayQueryServiceTest {
             Double latitude = 2.0;
             int distance = 3;
             List<String> hashtags = new ArrayList<>();
-            LocalDateTime createdAt = LocalDateTime.now();
-            Integer lastLikes = 20;
+            Walkway walkway = WalkwayFixture.createWalkway(null);
             int size = 10;
 
             SearchWalkwayPopular searchWalkwayPopular
-                    = new SearchWalkwayPopular(userId, longitude, latitude, distance, hashtags, createdAt, lastLikes,
-                    size);
+                    = new SearchWalkwayPopular(userId, longitude, latitude, distance, hashtags, walkway, size);
 
             List<Walkway> walkways = new ArrayList<>();
             for(int i = 0; i < 10; i++) {
@@ -221,13 +219,11 @@ class WalkwayQueryServiceTest {
             Double latitude = 2.0;
             int distance = 3;
             List<String> hashtags = new ArrayList<>();
-            LocalDateTime createdAt = LocalDateTime.now();
-            Double lastRating = 5.0;
+            Walkway walkway = WalkwayFixture.createWalkway(null);
             int size = 10;
 
             SearchWalkwayRating searchWalkwayRating
-                    = new SearchWalkwayRating(userId, longitude, latitude, distance, hashtags, createdAt, lastRating,
-                    size);
+                    = new SearchWalkwayRating(userId, longitude, latitude, distance, hashtags, walkway, size);
 
             List<Walkway> walkways = new ArrayList<>();
             for(int i = 0; i < 10; i++) {


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

## 📄 Work Description
<strong>Jira Ticket : `DB-99`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. 산책로 API 수정
![image](https://github.com/user-attachments/assets/83fbca91-ed08-4f6e-9e5a-1e00291ddfc2)
빠져있던 부분들을 추가해 API를 수정

![image](https://github.com/user-attachments/assets/1e69b249-8815-46e3-bcd1-7894343a278e)
1. 기존 조건으로는 검색한 해쉬태그만 반환되어 서브 쿼리를 사용하는 방식으로 변경
2. ExposeLevel이 PUBLIC인 산책로만 조회하게 변경
3. 정확한 최신순 정렬을 위해 검색, 정렬 조건을 id에서 createdAt으로 변경

#### 2. 산책로 단건 조회 API 수정
![image](https://github.com/user-attachments/assets/3a5b6880-3bda-43c8-b6f1-8c5db31d8ba6)
accessLevel enum으로 수정

<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->


<br/>

## 🔗 Reference
[//]: # (문제를 해결하면서 도움이 되었거나 참고했던 사이트 또는 코드 첨부)
