### PR TITLE
[feature/DB-140] 토큰 만료기간 확인 API 개발

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,7 +52,7 @@ jobs:
             sudo docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} -p ${{ secrets.DOCKER_HUB_PASSWORD }}
             sudo docker ps
             if [ "$(sudo docker ps -qa)" ]; then
-            sudo docker rm -f $(sudo docker ps -qa)
+            sudo docker rm -f $(sudo docker ps -qa | grep -v $(sudo docker ps -q -f name=dongsan-redis))
             fi
             sudo docker pull ${{ secrets.DOCKER_REPO }}:latest
             sudo docker run -d --network dongsan-network -p 8080:8080 ${{secrets.DOCKER_REPO}}:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    branches:
+      - develop
 
 jobs:
   build:

--- a/app-external-api/src/main/java/com/dongsan/config/SecurityConfig.java
+++ b/app-external-api/src/main/java/com/dongsan/config/SecurityConfig.java
@@ -117,7 +117,7 @@ public class SecurityConfig {
                         UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
                         // Admin 경로에 있어야 하는 role
-                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                        //.requestMatchers("/admin/**").hasRole("ADMIN")
                         // 인증 없이 접근 가능
                         .requestMatchers(
                                 "/",

--- a/app-external-api/src/main/java/com/dongsan/domains/auth/service/JwtService.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/auth/service/JwtService.java
@@ -93,7 +93,6 @@ public class JwtService {
         });
     }
 
-
     public boolean isAccessTokenExpired(String accessToken){
         return isTokenExpired(accessToken, accessTokenSecretKey, TokenType.ACCESS);
     }
@@ -103,17 +102,25 @@ public class JwtService {
     }
 
     private boolean isTokenExpired(String token, SecretKey secretKey, TokenType tokenType) {
-        try {
-            return extractAll(token, secretKey)
-                    .getExpiration()
-                    .before(new Date());
+        long remainingTime = getRemainingTimeMillis(token, secretKey);
+        if(remainingTime == 0){
+            switch (tokenType) {
+                case ACCESS -> throw new CustomException(AuthErrorCode.ACCESS_TOKEN_EXPIRED);
+                case REFRESH -> throw new CustomException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
+            }
+        }
+        return false;
+    }
+
+    public long getRemainingTimeMillis(String token, SecretKey secretKey){
+        try{
+            Date expiration = extractAll(token, secretKey).getExpiration();
+            long remainingTime = expiration.getTime() - System.currentTimeMillis();
+            return Math.max(remainingTime, 0);
         } catch (JwtException e) {
             if (e instanceof ExpiredJwtException) {
                 log.info("[AUTH_INFO] JWT 토큰이 만료: {}", e.getMessage());
-                switch (tokenType) {
-                    case ACCESS -> throw new CustomException(AuthErrorCode.ACCESS_TOKEN_EXPIRED);
-                    case REFRESH -> throw new CustomException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
-                }
+                return 0;
             }
             if (e instanceof MalformedJwtException) {
                 log.warn("[AUTH_WARNING] JWT 토큰 형식이 올바르지 않음: {}", e.getMessage());
@@ -129,6 +136,14 @@ public class JwtService {
                 throw new CustomException(SystemErrorCode.INTERNAL_SERVER_ERROR);
             }
         }
+    }
+
+    public long getAccessTokenRemainingTimeMillis(String token){
+        return getRemainingTimeMillis(token, accessTokenSecretKey);
+    }
+
+    public long getRefreshTokenRemainingTimeMillis(String token){
+        return getRemainingTimeMillis(token, refreshTokenSecretKey);
     }
 
     /**

--- a/app-external-api/src/main/java/com/dongsan/domains/auth/usecase/AuthUseCase.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/auth/usecase/AuthUseCase.java
@@ -6,6 +6,7 @@ import com.dongsan.common.error.exception.CustomException;
 import com.dongsan.domains.auth.AuthService;
 import com.dongsan.domains.auth.dto.RenewToken;
 import com.dongsan.domains.auth.service.JwtService;
+import com.dongsan.domains.dev.dto.response.GetTokenRemaining;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
@@ -43,5 +44,17 @@ public class AuthUseCase {
             return new RenewToken(newAccessToken, newRefreshToken);
         }
         throw new CustomException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
+    }
+
+    /**
+     * 토큰의 만료기간을 확인하는 로직
+     * @param accessToken
+     * @param refreshToken
+     */
+    public GetTokenRemaining checkTokenExpire(String accessToken, String refreshToken) {
+        long accessTokenRemaining = jwtService.getAccessTokenRemainingTimeMillis(accessToken);
+        long refreshTokenRemaining = jwtService.getRefreshTokenRemainingTimeMillis(refreshToken);
+
+        return new GetTokenRemaining(accessTokenRemaining, refreshTokenRemaining);
     }
 }

--- a/app-external-api/src/main/java/com/dongsan/domains/dev/controller/DevController.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/dev/controller/DevController.java
@@ -3,9 +3,12 @@ package com.dongsan.domains.dev.controller;
 import com.dongsan.common.apiResponse.ResponseFactory;
 import com.dongsan.common.apiResponse.SuccessResponse;
 import com.dongsan.domains.auth.AuthService;
+import com.dongsan.domains.auth.usecase.AuthUseCase;
+import com.dongsan.domains.dev.dto.request.CheckTokenExpire;
 import com.dongsan.domains.dev.dto.request.GenerateTokenRequest;
 import com.dongsan.domains.dev.dto.response.GenerateTokenResponse;
 import com.dongsan.domains.dev.dto.response.GetMemberInfoResponse;
+import com.dongsan.domains.dev.dto.response.GetTokenRemaining;
 import com.dongsan.domains.dev.usecase.DevUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -35,6 +38,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 public class DevController {
     private final DevUseCase devUseCase;
+    private final AuthUseCase authUseCase;
     private final AuthService authService;
 
     @Operation(summary = "개발용 토큰 발급")
@@ -58,11 +62,20 @@ public class DevController {
     @Operation(summary = "memberId로 서버에 저장된 refreshToken 확인하기")
     @GetMapping("/token/refresh")
     public ResponseEntity<SuccessResponse<Map<String, String>>> getRefreshToken(
-            @RequestParam @RequestBody Long memberId
+            @RequestParam Long memberId
     ){
         String refreshToken = authService.getRefreshToken(memberId);
         Map<String, String> response = new HashMap<>();
         response.put("refreshToken", refreshToken);
+        return ResponseFactory.ok(response);
+    }
+
+    @Operation(summary = "access token, refresh token의 만료기간 확인")
+    @PostMapping("/token/expired")
+    public ResponseEntity<SuccessResponse<GetTokenRemaining>> checkTokenExpire(
+            @RequestBody CheckTokenExpire tokens
+    ){
+        GetTokenRemaining response = authUseCase.checkTokenExpire(tokens.accessToken(), tokens.refreshToken());
         return ResponseFactory.ok(response);
     }
 

--- a/app-external-api/src/main/java/com/dongsan/domains/dev/dto/request/CheckTokenExpire.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/dev/dto/request/CheckTokenExpire.java
@@ -1,0 +1,7 @@
+package com.dongsan.domains.dev.dto.request;
+
+public record CheckTokenExpire(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/app-external-api/src/main/java/com/dongsan/domains/dev/dto/response/GetTokenRemaining.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/dev/dto/response/GetTokenRemaining.java
@@ -1,0 +1,27 @@
+package com.dongsan.domains.dev.dto.response;
+
+public record GetTokenRemaining(
+        boolean accessTokenExpired,
+        boolean refreshTokenExpired,
+        String accessTokenRemaining,
+        String refreshTokenRemaining
+) {
+    public GetTokenRemaining(long accessTokenRemainingTime, long refreshTokenRemainingTime){
+        this(
+                accessTokenRemainingTime == 0,
+                refreshTokenRemainingTime == 0,
+                formatTime(accessTokenRemainingTime),
+                formatTime(refreshTokenRemainingTime)
+        );
+    }
+
+    // 밀리초를 "HH:mm:ss" 형식으로 변환하는 메서드
+    private static String formatTime(long millis) {
+        long seconds = millis / 1000;
+        long hours = seconds / 3600;
+        long minutes = (seconds % 3600) / 60;
+        long remainingSeconds = seconds % 60;
+
+        return String.format("%02d:%02d:%02d", hours, minutes, remainingSeconds);
+    }
+}

--- a/app-external-api/src/test/java/com/dongsan/domains/dev/controller/DevControllerTest.java
+++ b/app-external-api/src/test/java/com/dongsan/domains/dev/controller/DevControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.dongsan.domains.auth.AuthService;
+import com.dongsan.domains.auth.usecase.AuthUseCase;
 import com.dongsan.domains.dev.dto.request.GenerateTokenRequest;
 import com.dongsan.domains.dev.dto.response.GenerateTokenResponse;
 import com.dongsan.domains.dev.dto.response.GetMemberInfoResponse;
@@ -36,6 +37,8 @@ class DevControllerTest {
     DevUseCase devUseCase;
     @MockBean
     AuthService authService;
+    @MockBean
+    AuthUseCase authUseCase;
 
     @Nested
     @DisplayName("generateToken 메소드는")


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

## 📄 Work Description
<strong>Jira Ticket : `DB-140`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. 토큰 만료기간 확인 API 개발
access token, refresh token 만료기간을 확인하는 개발용 API를 만들어 달라는 요청이 있어서 개발했습니다. 반환값으로 토큰 만료 유무를 boolean 타입으로도 보내주고, "hh:mm:ss"로 만료까지 남은 시간도 알려줍니다.
![스크린샷 2025-02-04 오후 1 32 41](https://github.com/user-attachments/assets/b523a22a-fb42-4808-9a78-dffef409cc93)

#### 2. ci, cd 스크립트 수정
- ci : ci 스크립트가 develop 브랜치에 PR 할때만 동작하도록 수정했습니다.
- cd : CD 할 때, 운영 서버에서 redis 컨테이너가 삭제되지 않도록 수정했습니다.

#### 3. 쿠키 필드 명 카멜케이스로 변경
쿠키 필드 명 카멜케이스로 변경해달라는 요청이 있어서 변경했습니다.
<img width="651" alt="스크린샷 2025-02-04 오후 1 57 08" src="https://github.com/user-attachments/assets/54f510a0-1eea-4176-9b37-2d37d0d3a813" />