### PR TITLE
[hotfix/DB-144]: 토큰 만료기간 확인 API - Refresh Token 로직 수정

### DIFF
--- a/app-external-api/src/main/java/com/dongsan/domains/auth/service/JwtService.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/auth/service/JwtService.java
@@ -31,8 +31,8 @@ public class JwtService {
     private final MemberRepository memberRepository;
     @Value("${jwt.access.secret}")
     private String accessTokenSecret;
-    @Value("${jwt.access.expires-in}")
-    private long accessTokenExpiresIn;
+    //@Value("${jwt.access.expires-in}")
+    private long accessTokenExpiresIn = 5 * 60 * 1000; // 테스트 위해 5분으로 설정
     @Value("${jwt.refresh.secret}")
     private String refreshTokenSecret;
     @Value("${jwt.refresh.expires-in}")

--- a/app-external-api/src/main/java/com/dongsan/domains/auth/usecase/AuthUseCase.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/auth/usecase/AuthUseCase.java
@@ -54,6 +54,12 @@ public class AuthUseCase {
     public GetTokenRemaining checkTokenExpire(String accessToken, String refreshToken) {
         long accessTokenRemaining = jwtService.getAccessTokenRemainingTimeMillis(accessToken);
         long refreshTokenRemaining = jwtService.getRefreshTokenRemainingTimeMillis(refreshToken);
+        if(refreshTokenRemaining > 0){
+            Long memberId = jwtService.getMemberFromRefreshToken(refreshToken).getId();
+            if(!authService.isRefreshTokenNotReplaced(memberId, refreshToken)){
+                refreshTokenRemaining = 0;
+            }
+        }
 
         return new GetTokenRemaining(accessTokenRemaining, refreshTokenRemaining);
     }


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

## 📄 Work Description
<strong>Jira Ticket : `DB-144`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. 토큰 만료기간 확인 API - Refresh Token 로직 수정
"/dev/token/expired" 에서 Refresh Token을 재발급 받고 나서, 그 재발급 전의 Refresh Token(서버에서 새로운 Refresh Token으로 교체됨)의 만료 기간을 확인할 때 만료 되지 않았다고 뜨는 에러가 있었습니다. 
해결을 위해, Refresh Token의 redis 저장 여부까지 확인해서 만료 기간을 반환했습니다.


#### 2. Access Token 만료기간 수정
프론트엔드에서 토큰 테스트 시에 Access Token 만료기간을 5분으로 변경해달라는 요청이 있어서 그에 맞게 변경했습니다.

