### PR TITLE
[fix/DB-157]: 로그인 리다이렉팅 수정 및 토큰 만료 시 쿠키 삭제 로직 추가

### DIFF
--- a/app-external-api/src/main/java/com/dongsan/domains/auth/controller/AuthController.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/auth/controller/AuthController.java
@@ -37,9 +37,10 @@ public class AuthController {
     @Operation(summary = "로그 아웃")
     @DeleteMapping("/logout")
     public ResponseEntity<Void> logout(
-            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+            HttpServletResponse response
     ){
-        authUseCase.logout(customOAuth2User.getMemberId());
+        authUseCase.logout(customOAuth2User.getMemberId(), response);
         return ResponseFactory.noContent();
     }
 }

--- a/app-external-api/src/main/java/com/dongsan/domains/auth/controller/AuthController.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/auth/controller/AuthController.java
@@ -6,7 +6,6 @@ import com.dongsan.domains.auth.security.oauth2.dto.CustomOAuth2User;
 import com.dongsan.domains.auth.usecase.AuthUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -29,10 +28,9 @@ public class AuthController {
     @PostMapping("/refresh")
     public ResponseEntity<Void> renewToken(
             @RequestBody RefreshToken dto,
-            HttpServletRequest request,
             HttpServletResponse response
     ){
-        authUseCase.renewToken(dto.refreshToken(), request, response);
+        authUseCase.renewToken(dto.refreshToken(), response);
         return ResponseEntity.ok().build();
     }
 

--- a/app-external-api/src/main/java/com/dongsan/domains/auth/security/oauth2/handler/CustomSuccessHandler.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/auth/security/oauth2/handler/CustomSuccessHandler.java
@@ -24,11 +24,8 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     private final CookieService cookieService;
     private final AuthService authService;
 
-    @Value("${frontend.dev-redirect-url}")
-    private String devRedirectUrl;
-
-    @Value("${frontend.prod-redirect-url}")
-    private String prodRedirectUrl;
+    @Value("${frontend.redirect-url}")
+    private String redirectUrl;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -39,21 +36,11 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String accessToken = jwtService.createAccessToken(memberId);
         String refreshToken = jwtService.createRefreshToken(memberId);
 
-        // refreshToken 저장
         authService.saveRefreshToken(memberId, refreshToken);
 
-        response.addCookie(cookieService.createAccessTokenCookie(accessToken, request));
-        response.addCookie(cookieService.createRefreshTokenCookie(refreshToken, request));
+        response.addCookie(cookieService.createAccessTokenCookie(accessToken));
+        response.addCookie(cookieService.createRefreshTokenCookie(refreshToken));
 
-        // 주소 분기
-        String redirectUrl;
-        String referer = request.getHeader("Referer");
-        log.info("[cookie : referer] " + referer);
-        if (referer.contains("localhost")) {
-            redirectUrl = devRedirectUrl;
-        } else {
-            redirectUrl = prodRedirectUrl;
-        }
         response.sendRedirect(redirectUrl);
     }
 }

--- a/app-external-api/src/main/java/com/dongsan/domains/auth/service/CookieService.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/auth/service/CookieService.java
@@ -1,7 +1,6 @@
 package com.dongsan.domains.auth.service;
 
 import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -10,11 +9,8 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class CookieService {
 
-    @Value("${cookie.dev-domain}")
-    private String devDomain;
-
-    @Value("${cookie.prod-domain}")
-    private String prodDomain;
+    @Value("${cookie.domain}")
+    private String domain;
 
     @Value("${cookie.access-name}")
     private String accessTokenName;
@@ -28,18 +24,19 @@ public class CookieService {
     @Value("${cookie.rt-max-age}")
     private int refreshTokenMaxAge;
 
-    public Cookie createAccessTokenCookie(String token, HttpServletRequest request) {
-        return createTokenCookie(accessTokenName, token, accessTokenMaxAge, request);
+    public Cookie createAccessTokenCookie(String token) {
+        return createTokenCookie(accessTokenName, token, accessTokenMaxAge);
     }
 
-    public Cookie createRefreshTokenCookie(String token, HttpServletRequest request) {
-        return createTokenCookie(refreshTokenName, token, refreshTokenMaxAge, request);
+    public Cookie createRefreshTokenCookie(String token) {
+        return createTokenCookie(refreshTokenName, token, refreshTokenMaxAge);
     }
 
     // 로그인 직후 로컬스토리지로 이동시키기 때문에 만료시간을 짧게 설정
-    private Cookie createTokenCookie(String cookieName, String token, int maxAge, HttpServletRequest request) {
+    private Cookie createTokenCookie(String cookieName, String token, int maxAge) {
         Cookie cookie = new Cookie(cookieName, token);
         cookie.setMaxAge(maxAge);
+        cookie.setDomain(domain);
         cookie.setPath("/");
         cookie.setHttpOnly(false);
 
@@ -47,14 +44,6 @@ public class CookieService {
         cookie.setAttribute("SameSite", "None");
         cookie.setSecure(true);
 
-        // 로컬호스트와 배포 주소 분기
-        String referer = request.getHeader("Referer");
-        log.info("[cookie : referer] " + referer);
-        if (referer.contains("localhost")) {
-            cookie.setDomain(devDomain); // 로컬호스트 도메인
-        } else {
-            cookie.setDomain(prodDomain); // 배포 도메인
-        }
         return cookie;
     }
 }

--- a/app-external-api/src/main/java/com/dongsan/domains/auth/service/CookieService.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/auth/service/CookieService.java
@@ -32,7 +32,14 @@ public class CookieService {
         return createTokenCookie(refreshTokenName, token, refreshTokenMaxAge);
     }
 
-    // 로그인 직후 로컬스토리지로 이동시키기 때문에 만료시간을 짧게 설정
+    public Cookie deleteAccessTokenCookie(){
+        return createTokenCookie(accessTokenName, "", 0);
+    }
+
+    public Cookie deleteRefreshTokenCookie(){
+        return createTokenCookie(refreshTokenName, "", 0);
+    }
+
     private Cookie createTokenCookie(String cookieName, String token, int maxAge) {
         Cookie cookie = new Cookie(cookieName, token);
         cookie.setMaxAge(maxAge);
@@ -46,4 +53,5 @@ public class CookieService {
 
         return cookie;
     }
+
 }

--- a/app-external-api/src/main/java/com/dongsan/domains/auth/usecase/AuthUseCase.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/auth/usecase/AuthUseCase.java
@@ -7,7 +7,6 @@ import com.dongsan.domains.auth.AuthService;
 import com.dongsan.domains.auth.service.CookieService;
 import com.dongsan.domains.auth.service.JwtService;
 import com.dongsan.domains.dev.dto.response.GetTokenRemaining;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -30,11 +29,10 @@ public class AuthUseCase {
      * 시도 하라고 에러 반환 -> value 와 동일한 토큰 : 토큰 갱신
      *
      * @param refreshToken 기존에 발급 받은 refresh token
-     * @param request
      * @param response
      * @return 새로 갱신한 access token & refresh token
      */
-    public void renewToken(String refreshToken, HttpServletRequest request, HttpServletResponse response) {
+    public void renewToken(String refreshToken, HttpServletResponse response) {
         if(jwtService.isRefreshTokenExpired(refreshToken)){
             throw new CustomException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
         }
@@ -44,8 +42,8 @@ public class AuthUseCase {
             String newAccessToken = jwtService.createAccessToken(memberId);
             String newRefreshToken = jwtService.createRefreshToken(memberId);
             authService.saveRefreshToken(memberId, newRefreshToken);
-            response.addCookie(cookieService.createAccessTokenCookie(newAccessToken, request));
-            response.addCookie(cookieService.createRefreshTokenCookie(newRefreshToken, request));
+            response.addCookie(cookieService.createAccessTokenCookie(newAccessToken));
+            response.addCookie(cookieService.createRefreshTokenCookie(newRefreshToken));
         }
         throw new CustomException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
     }

--- a/app-external-api/src/main/java/com/dongsan/domains/dev/controller/DevController.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/dev/controller/DevController.java
@@ -11,7 +11,6 @@ import com.dongsan.domains.dev.dto.response.GetTokenRemaining;
 import com.dongsan.domains.dev.usecase.DevUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotBlank;
 import java.io.IOException;
@@ -45,11 +44,10 @@ public class DevController {
     @Operation(summary = "개발용 토큰 발급")
     @PostMapping("/token")
     public ResponseEntity<Void> generateToken(
-            @RequestBody GenerateTokenRequest request,
-            HttpServletRequest httpServletRequest,
+            @RequestBody GenerateTokenRequest dto,
             HttpServletResponse httpServletResponse
     ){
-        devUseCase.generateToken(request.memberId(), httpServletRequest, httpServletResponse);
+        devUseCase.generateToken(dto.memberId(), httpServletResponse);
         return ResponseEntity.ok().build();
     }
 

--- a/app-external-api/src/main/java/com/dongsan/domains/dev/usecase/DevUseCase.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/dev/usecase/DevUseCase.java
@@ -9,7 +9,6 @@ import com.dongsan.domains.dev.mapper.DevMapper;
 import com.dongsan.domains.member.entity.Member;
 import com.dongsan.domains.user.service.MemberQueryService;
 import com.dongsan.service.S3FileService;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
@@ -26,13 +25,13 @@ public class DevUseCase {
     private final S3FileService s3FileService;
 
     @Transactional
-    public void generateToken(Long memberId, HttpServletRequest httpServletRequest, HttpServletResponse response){
+    public void generateToken(Long memberId, HttpServletResponse response){
         memberQueryService.getMember(memberId);
         String accessToken = jwtService.createAccessToken(memberId);
         String refreshToken = jwtService.createRefreshToken(memberId);
         authService.saveRefreshToken(memberId, refreshToken);
-        response.addCookie(cookieService.createAccessTokenCookie(accessToken, httpServletRequest));
-        response.addCookie(cookieService.createRefreshTokenCookie(refreshToken, httpServletRequest));
+        response.addCookie(cookieService.createAccessTokenCookie(accessToken));
+        response.addCookie(cookieService.createRefreshTokenCookie(refreshToken));
     }
 
     @Transactional

--- a/app-external-api/src/test/java/com/dongsan/domains/dev/usecase/DevUseCaseTest.java
+++ b/app-external-api/src/test/java/com/dongsan/domains/dev/usecase/DevUseCaseTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 @ExtendWith(MockitoExtension.class)
@@ -50,15 +49,14 @@ class DevUseCaseTest {
             when(jwtService.createAccessToken(memberId)).thenReturn(accessToken);
             when(jwtService.createRefreshToken(memberId)).thenReturn(refreshToken);
             doNothing().when(authService).saveRefreshToken(memberId, refreshToken);
-            MockHttpServletRequest httpServletRequest = new MockHttpServletRequest();
             MockHttpServletResponse httpServletResponse = new MockHttpServletResponse();
             Cookie atCookie = new Cookie("accessToken", accessToken);
             Cookie rtCookie = new Cookie("refreshToken", refreshToken);
-            when(cookieService.createAccessTokenCookie(accessToken, httpServletRequest)).thenReturn(atCookie);
-            when(cookieService.createRefreshTokenCookie(refreshToken, httpServletRequest)).thenReturn(rtCookie);
+            when(cookieService.createAccessTokenCookie(accessToken)).thenReturn(atCookie);
+            when(cookieService.createRefreshTokenCookie(refreshToken)).thenReturn(rtCookie);
 
             // when
-            devUseCase.generateToken(memberId, httpServletRequest, httpServletResponse);
+            devUseCase.generateToken(memberId, httpServletResponse);
 
             // then
             Cookie[] cookies = httpServletResponse.getCookies();


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

## 📄 Work Description
<strong>Jira Ticket : `DB-157`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. 로그인 리다이렉팅 수정 
배포 환경에서 로그인 완료 후 리다이렉팅 주소를 프론트엔드의 개발 환경 여부와 상관없이 배포된 주소로 리다이렉팅 되도록 수정했습니다.

#### 2. 토큰 만료 시 쿠키 삭제 로직 추가
로그아웃 했을 때, 토큰을 재발급 받으려고 할 때 리프레시 토큰이 만료될 때 쿠키에서 토큰들이 삭제되는 로직을 추가했습니다.