### PR TITLE
[fix/DB-164]: 토큰 발급 로직 response body로 수정

### DIFF
--- a/app-external-api/src/main/java/com/dongsan/domains/auth/controller/AuthController.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.dongsan.domains.auth.controller;
 
 import com.dongsan.common.apiResponse.ResponseFactory;
 import com.dongsan.domains.auth.dto.RefreshToken;
+import com.dongsan.domains.auth.dto.RenewToken;
 import com.dongsan.domains.auth.security.oauth2.dto.CustomOAuth2User;
 import com.dongsan.domains.auth.usecase.AuthUseCase;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,12 +27,12 @@ public class AuthController {
     // Access token 재발급 (Refresh Token을 받으면 재발급)
     @Operation(summary = "Access token 재발급 (Refresh Token을 받으면 Access token & Refresh Token 재발급, Refresh Token 만료 시 다시 로그인 진행해야 함)")
     @PostMapping("/refresh")
-    public ResponseEntity<Void> renewToken(
+    public ResponseEntity<RenewToken> renewToken(
             @RequestBody RefreshToken dto,
             HttpServletResponse response
     ){
-        authUseCase.renewToken(dto.refreshToken(), response);
-        return ResponseEntity.ok().build();
+        RenewToken renewed = authUseCase.renewToken(dto.refreshToken(), response);
+        return ResponseEntity.ok(renewed);
     }
 
     @Operation(summary = "로그 아웃")

--- a/app-external-api/src/main/java/com/dongsan/domains/auth/dto/RenewToken.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/auth/dto/RenewToken.java
@@ -1,0 +1,7 @@
+package com.dongsan.domains.auth.dto;
+
+public record RenewToken(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/app-external-api/src/main/java/com/dongsan/domains/auth/usecase/AuthUseCase.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/auth/usecase/AuthUseCase.java
@@ -4,6 +4,7 @@ import com.dongsan.common.annotation.UseCase;
 import com.dongsan.common.error.code.AuthErrorCode;
 import com.dongsan.common.error.exception.CustomException;
 import com.dongsan.domains.auth.AuthService;
+import com.dongsan.domains.auth.dto.RenewToken;
 import com.dongsan.domains.auth.service.CookieService;
 import com.dongsan.domains.auth.service.JwtService;
 import com.dongsan.domains.dev.dto.response.GetTokenRemaining;
@@ -34,7 +35,7 @@ public class AuthUseCase {
      * @param response
      * @return 새로 갱신한 access token & refresh token
      */
-    public void renewToken(String refreshToken, HttpServletResponse response) {
+    public RenewToken renewToken(String refreshToken, HttpServletResponse response) {
         if(jwtService.isRefreshTokenExpired(refreshToken)){
             response.addCookie(cookieService.deleteAccessTokenCookie());
             response.addCookie(cookieService.deleteRefreshTokenCookie());
@@ -48,7 +49,7 @@ public class AuthUseCase {
             authService.saveRefreshToken(memberId, newRefreshToken);
             response.addCookie(cookieService.createAccessTokenCookie(newAccessToken));
             response.addCookie(cookieService.createRefreshTokenCookie(newRefreshToken));
-            return;
+            return new RenewToken(newAccessToken, newRefreshToken);
         }
         response.addCookie(cookieService.deleteAccessTokenCookie());
         response.addCookie(cookieService.deleteRefreshTokenCookie());

--- a/app-external-api/src/main/java/com/dongsan/domains/dev/controller/DevController.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/dev/controller/DevController.java
@@ -3,6 +3,7 @@ package com.dongsan.domains.dev.controller;
 import com.dongsan.common.apiResponse.ResponseFactory;
 import com.dongsan.common.apiResponse.SuccessResponse;
 import com.dongsan.domains.auth.AuthService;
+import com.dongsan.domains.auth.dto.RenewToken;
 import com.dongsan.domains.auth.usecase.AuthUseCase;
 import com.dongsan.domains.dev.dto.request.CheckTokenExpire;
 import com.dongsan.domains.dev.dto.request.GenerateTokenRequest;
@@ -43,12 +44,12 @@ public class DevController {
 
     @Operation(summary = "개발용 토큰 발급")
     @PostMapping("/token")
-    public ResponseEntity<Void> generateToken(
+    public ResponseEntity<RenewToken> generateToken(
             @RequestBody GenerateTokenRequest dto,
             HttpServletResponse httpServletResponse
     ){
-        devUseCase.generateToken(dto.memberId(), httpServletResponse);
-        return ResponseEntity.ok().build();
+        RenewToken response = devUseCase.generateToken(dto.memberId(), httpServletResponse);
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "accessToken으로 member 정보 확인하기")

--- a/app-external-api/src/main/java/com/dongsan/domains/dev/usecase/DevUseCase.java
+++ b/app-external-api/src/main/java/com/dongsan/domains/dev/usecase/DevUseCase.java
@@ -2,6 +2,7 @@ package com.dongsan.domains.dev.usecase;
 
 import com.dongsan.common.annotation.UseCase;
 import com.dongsan.domains.auth.AuthService;
+import com.dongsan.domains.auth.dto.RenewToken;
 import com.dongsan.domains.auth.service.CookieService;
 import com.dongsan.domains.auth.service.JwtService;
 import com.dongsan.domains.dev.dto.response.GetMemberInfoResponse;
@@ -25,13 +26,14 @@ public class DevUseCase {
     private final S3FileService s3FileService;
 
     @Transactional
-    public void generateToken(Long memberId, HttpServletResponse response){
+    public RenewToken generateToken(Long memberId, HttpServletResponse response){
         memberQueryService.getMember(memberId);
         String accessToken = jwtService.createAccessToken(memberId);
         String refreshToken = jwtService.createRefreshToken(memberId);
         authService.saveRefreshToken(memberId, refreshToken);
         response.addCookie(cookieService.createAccessTokenCookie(accessToken));
         response.addCookie(cookieService.createRefreshTokenCookie(refreshToken));
+        return new RenewToken(accessToken, refreshToken);
     }
 
     @Transactional


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

## 📄 Work Description
<strong>Jira Ticket : `DB-164`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. 토큰 발급 로직 response body로 수정
프론트엔드에서 개발시에 쿠키를 로컬에서 파싱한 다음 자동으로 어플리케이션 쿠키탭에 저장되도록 해봤는데 브라우저 cors 정책때문에 파싱이 잘 안되는 것 같다는 대답이 있었습니다. 따라서 개발용 토큰 발급 API와 토큰 재발급 API에서 응답 유형으로 response body으로 토큰이 담기도록 수정했습니다.

