### PR TITLE
[feature/DB-238]: 탈퇴하기 API, 회원가입 시 프로필 사진 제외

### DIFF
--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/auth/AuthController.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/auth/AuthController.java
@@ -1,5 +1,9 @@
 package com.dongsan.api.domains.auth;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -7,41 +11,52 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
 @RestController
 @RequestMapping("/auth")
 @Tag(name = "인증")
 public class AuthController {
-	private final AuthService authService;
+    private final AuthService authService;
 
-	public AuthController(AuthService authService) {
-		this.authService = authService;
-	}
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
 
-	@Operation(summary = "Access token 재발급 (Refresh Token을 받으면 Access token & Refresh Token 재발급, Refresh Token 만료 시 다시"
-		+ " 로그인 진행해야 함)")
-	@PostMapping("/refresh")
-	public ResponseEntity<Void> renewToken(
-		HttpServletRequest request,
-		HttpServletResponse response
-	) {
-		authService.renewToken(request, response);
-		return ResponseEntity.ok()
-			.build();
-	}
+    @Operation(summary = "Access token 재발급 (Refresh Token을 받으면 Access token & Refresh Token 재발급, Refresh Token 만료 시 다시"
+            + " 로그인 진행해야 함)")
+    @PostMapping("/refresh")
+    public ResponseEntity<Void> renewToken(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        authService.renewToken(request, response);
+        return ResponseEntity.ok().build();
+    }
 
-	@Operation(summary = "로그 아웃")
-	@DeleteMapping("/logout")
-	public ResponseEntity<Void> logout(
-		@AuthenticationPrincipal CustomAuthUser customOAuth2User,
-		HttpServletResponse response
-	) {
-		authService.logout(customOAuth2User.getMemberId(), response);
-		return ResponseEntity.ok()
-			.build();
-	}
+    /**
+     * 우선은 빠른 재심사를 위해 로그아웃과 동일하게 토큰만 삭제하는 걸로 되어 있음.
+     * (개선 방식)
+     * 필드 추가해서 isDeactivated = true, deactivatedAt 설정
+     * 14일 지나면 데이터 아예 삭제 (spring batch 사용)
+     * 14일 내로 돌아오면 탈퇴하지 않은 걸로 다시 활동
+     * 삭제되거나 deactivate 된 사용자는 (알수없음) 으로 닉네임이 뜨도록 설정 필요 (도메인 객체에서 따로 매핑 해야 할듯)
+     */
+    @Operation(summary = "로그 아웃")
+    @DeleteMapping("/logout")
+    public ResponseEntity<Void> logout(
+            @AuthenticationPrincipal CustomAuthUser customOAuth2User,
+            HttpServletResponse response
+    ) {
+        authService.logout(customOAuth2User.getMemberId(), response);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "탈퇴하기")
+    @DeleteMapping("/deactivate")
+    public ResponseEntity<Void> deactivate(
+            @AuthenticationPrincipal CustomAuthUser customAuthUser,
+            HttpServletResponse response
+    ) {
+        authService.logout(customAuthUser.getMemberId(), response);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/auth/oauth2/CustomOAuthUserService.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/auth/oauth2/CustomOAuthUserService.java
@@ -1,7 +1,12 @@
 package com.dongsan.api.domains.auth.oauth2;
 
-import java.util.Map;
-
+import com.dongsan.api.domains.auth.AuthUserDto;
+import com.dongsan.api.domains.auth.CustomAccessDeniedHandler;
+import com.dongsan.api.domains.auth.CustomAuthUser;
+import com.dongsan.core.domains.auth.Provider;
+import com.dongsan.core.domains.member.Member;
+import com.dongsan.core.domains.member.MemberRole;
+import com.dongsan.core.domains.member.MemberService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -10,45 +15,40 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
-import com.dongsan.api.domains.auth.AuthUserDto;
-import com.dongsan.api.domains.auth.CustomAccessDeniedHandler;
-import com.dongsan.api.domains.auth.CustomAuthUser;
-import com.dongsan.core.domains.auth.Provider;
-import com.dongsan.core.domains.member.Member;
-import com.dongsan.core.domains.member.MemberRole;
-import com.dongsan.core.domains.member.MemberService;
+import java.util.Map;
 
 @Service
 public class CustomOAuthUserService extends DefaultOAuth2UserService {
-	private static final Logger log = LoggerFactory.getLogger(CustomAccessDeniedHandler.class);
+    private static final Logger log = LoggerFactory.getLogger(CustomAccessDeniedHandler.class);
 
-	private final MemberService memberService;
+    private final MemberService memberService;
 
-	public CustomOAuthUserService(MemberService memberService) {
-		this.memberService = memberService;
-	}
+    public CustomOAuthUserService(MemberService memberService) {
+        this.memberService = memberService;
+    }
 
-	/**
-	 * 사용자 정보 조회 <br>
-	 * - 신규 사용자의 경우 데이터 베이스에 저장
-	 * @param userRequest the user request
-	 * @return OAuth2User : SecurityContext 에 사용자 정보 저장
-	 */
-	@Override
-	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-		OAuth2User oAuth2User = super.loadUser(userRequest);
-		Map<String, Object> attributes = oAuth2User.getAttributes();
+    /**
+     * 사용자 정보 조회 <br>
+     * - 신규 사용자의 경우 데이터 베이스에 저장
+     *
+     * @param userRequest the user request
+     * @return OAuth2User : SecurityContext 에 사용자 정보 저장
+     */
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        Map<String, Object> attributes = oAuth2User.getAttributes();
 
-		String registrationId = userRequest.getClientRegistration()
-			.getRegistrationId();
-		Provider provider = Provider.of(registrationId);
-		OAuth2Attributes oAuth2Attributes = OAuth2Attributes.of(provider, attributes);
+        String registrationId = userRequest.getClientRegistration()
+                .getRegistrationId();
+        Provider provider = Provider.of(registrationId);
+        OAuth2Attributes oAuth2Attributes = OAuth2Attributes.of(provider, attributes);
 
-		Member member = memberService.getOptionalMemberByEmailAndProvider(oAuth2Attributes.email(), provider)
-			.orElseGet(() -> memberService.save(oAuth2Attributes.email(), oAuth2Attributes.nickname(),
-				oAuth2Attributes.profileImage(), MemberRole.ROLE_USER, provider));
-		log.info("[AUTH] 로그인 이메일 : %s".formatted(member.email()));
-		AuthUserDto user = new AuthUserDto(member);
-		return new CustomAuthUser(user);
-	}
+        Member member = memberService.getOptionalMemberByEmailAndProvider(oAuth2Attributes.email(), provider)
+                .orElseGet(() -> memberService.save(oAuth2Attributes.email(), oAuth2Attributes.nickname(),
+                        null, MemberRole.ROLE_USER, provider));
+        log.info("[AUTH] 로그인 이메일 : %s".formatted(member.email()));
+        AuthUserDto user = new AuthUserDto(member);
+        return new CustomAuthUser(user);
+    }
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/auth/oauth2/OAuth2Attributes.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/auth/oauth2/OAuth2Attributes.java
@@ -1,31 +1,29 @@
 package com.dongsan.api.domains.auth.oauth2;
 
-import java.util.Map;
-
 import com.dongsan.core.domains.auth.Provider;
 
+import java.util.Map;
+
 public record OAuth2Attributes(
-	String email,
-	String nickname,
-	String profileImage
+        String email,
+        String nickname
 ) {
 
-	public static OAuth2Attributes of(Provider socialType, Map<String, Object> attributes) {
-		return switch (socialType) {
-			case KAKAO -> ofKakao(attributes);
-			case NAVER -> ofNaver(attributes);
-		};
-	}
+    public static OAuth2Attributes of(Provider socialType, Map<String, Object> attributes) {
+        return switch (socialType) {
+            case KAKAO -> ofKakao(attributes);
+            case NAVER -> ofNaver(attributes);
+        };
+    }
 
-	private static OAuth2Attributes ofKakao(Map<String, Object> attributes) {
-		Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get("kakao_account");
-		Map<String, String> profile = (Map<String, String>)kakaoAccount.get("profile");
-		return new OAuth2Attributes((String)kakaoAccount.get("email"), profile.get("nickname"),
-			profile.get("profile_image_url"));
-	}
+    private static OAuth2Attributes ofKakao(Map<String, Object> attributes) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, String> profile = (Map<String, String>) kakaoAccount.get("profile");
+        return new OAuth2Attributes((String) kakaoAccount.get("email"), profile.get("nickname"));
+    }
 
-	private static OAuth2Attributes ofNaver(Map<String, Object> attributes) {
-		Map<String, String> response = (Map<String, String>)attributes.get("response");
-		return new OAuth2Attributes(response.get("email"), response.get("nickname"), response.get("profile_image"));
-	}
+    private static OAuth2Attributes ofNaver(Map<String, Object> attributes) {
+        Map<String, String> response = (Map<String, String>) attributes.get("response");
+        return new OAuth2Attributes(response.get("email"), response.get("nickname"));
+    }
 }


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

## 📄 Work Description
<strong>Jira Ticket : `DB-238`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. 탈퇴하기 API 구현
우선은 빠른 재심사를 위해 로그아웃과 동일하게 토큰만 삭제하는걸로 구현했습니다. 
(개선 방식)
- 필드 추가해서 isDeactivated = true, deactivatedAt 설정
- 14일 지나면 데이터 아예 삭제 (spring batch 사용)
- 14일 내로 돌아오면 탈퇴하지 않은 걸로 다시 활동
- 삭제되거나 deactivate 된 사용자는 (알수없음) 으로 닉네임이 뜨도록 설정 필요 (도메인 객체에서 따로 매핑 해야 할듯)


#### 2. 회원가입 시 프로필 사진 제외
앱 심사 시에 provider에게 프로필 사진을 제공받으면 안된다는 조항이 있었습니다.


<br/>

