### PR TITLE
[feature/DB-253]: 디스코드 웹 훅

### DIFF
--- a/dongsan-external-api/build.gradle
+++ b/dongsan-external-api/build.gradle
@@ -23,6 +23,9 @@ dependencies {
 
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    // feign (webhook용)
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.4'
 }
 
 // application.yml 설정 파일 복사

--- a/dongsan-external-api/src/main/java/com/dongsan/ExternalApiApplication.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/ExternalApiApplication.java
@@ -2,12 +2,14 @@ package com.dongsan;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class ExternalApiApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(ExternalApiApplication.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(ExternalApiApplication.class, args);
+	}
 
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/dev/DevController.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/dev/DevController.java
@@ -91,4 +91,9 @@ public class DevController {
 		return ResponseEntity.ok(url);
 	}
 
+	@Operation(summary = "에러 발생 테스트")
+	@GetMapping("/exception")
+	public void exception() throws Exception {
+		throw new Exception("에러 발생");
+	}
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/support/response/DiscordClient.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/support/response/DiscordClient.java
@@ -1,0 +1,13 @@
+package com.dongsan.api.support.response;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(
+	name = "discord-client",
+	url = "${discord.webhook.url}")
+public interface DiscordClient {
+	@PostMapping()
+	void sendAlarm(@RequestBody DiscordMessage message);
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/api/support/response/DiscordMessage.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/support/response/DiscordMessage.java
@@ -1,0 +1,53 @@
+package com.dongsan.api.support.response;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public record DiscordMessage(
+	String content,
+	List<Embed> embeds
+) {
+	public record Embed(
+		String title,
+		String description
+	) {
+	}
+
+	public static DiscordMessage fromException(Exception e, HttpServletRequest request) {
+		String content = "# 🚨 에러 발생 비이이이이사아아아앙";
+		String description = "### 🕖 발생 시간\n"
+			+ LocalDateTime.now()
+			+ "\n"
+			+ "### 🔗 요청 URL\n"
+			+ createRequestFullPath(request)
+			+ "\n"
+			+ "### 📄 Stack Trace\n"
+			+ "```\n"
+			+ getStackTrace(e).substring(0, 1000)
+			+ "\n```";
+
+		Embed embed = new Embed("ℹ️ 에러 정보", description);
+		return new DiscordMessage(content, List.of(embed));
+	}
+
+	private static String createRequestFullPath(HttpServletRequest request) {
+		String fullPath = request.getMethod() + " " + request.getRequestURL();
+
+		String queryString = request.getQueryString();
+		if (queryString != null) {
+			fullPath += "?" + queryString;
+		}
+
+		return fullPath;
+	}
+
+	private static String getStackTrace(Exception e) {
+		StringWriter stringWriter = new StringWriter();
+		e.printStackTrace(new PrintWriter(stringWriter));
+		return stringWriter.toString();
+	}
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/api/support/response/ExceptionAdvice.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/support/response/ExceptionAdvice.java
@@ -1,12 +1,11 @@
 package com.dongsan.api.support.response;
 
-import java.util.Arrays;
+import com.dongsan.api.support.response.discord.DiscordNotifier;
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.NestedExceptionUtils;
-import org.springframework.core.env.Environment;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -31,14 +30,12 @@ import jakarta.validation.ConstraintViolationException;
 
 @RestControllerAdvice(annotations = {RestController.class})
 public class ExceptionAdvice extends ResponseEntityExceptionHandler {
-	private final DiscordClient discordClient;
-	private final Environment environment;
+	private final DiscordNotifier discordNotifier;
 
 	private static final Logger log = LoggerFactory.getLogger(ExceptionAdvice.class);
 
-	public ExceptionAdvice(DiscordClient discordClient, Environment environment) {
-		this.discordClient = discordClient;
-		this.environment = environment;
+	public ExceptionAdvice(DiscordNotifier discordNotifier) {
+		this.discordNotifier = discordNotifier;
 	}
 
 	@ExceptionHandler(value = CoreException.class)
@@ -74,9 +71,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 	public ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
 		log.error("[Exception] cause: {} , message: {}", NestedExceptionUtils.getMostSpecificCause(e), e.getMessage());
 		SystemErrorCode errorCode = SystemErrorCode.INTERNAL_SERVER_ERROR;
-		if (!Arrays.asList(environment.getActiveProfiles()).contains("local")) {
-			sendDiscordAlarm(e, request);
-		}
+		discordNotifier.notify(e, request);
 		return ResponseEntity
 			.status(errorCode.getHttpStatus())
 			.body(ErrorResponse.from(errorCode.getCode(), errorCode.getMessage()));
@@ -127,11 +122,5 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 		return ResponseEntity
 			.status(errorCode.getHttpStatus())
 			.body(ErrorResponse.from(errorCode.getCode(), errorCode.getMessage(), errors));
-	}
-
-	private void sendDiscordAlarm(Exception e, HttpServletRequest request) {
-		discordClient.sendAlarm(
-			DiscordMessage.fromException(e, request)
-		);
 	}
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/support/response/ExceptionAdvice.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/support/response/ExceptionAdvice.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.NestedExceptionUtils;
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -24,11 +25,20 @@ import com.dongsan.core.support.error.CoreErrorCode;
 import com.dongsan.core.support.error.CoreErrorStatus;
 import com.dongsan.core.support.error.CoreException;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 
 @RestControllerAdvice(annotations = {RestController.class})
 public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+	private final DiscordClient discordClient;
+	private final Environment environment;
+
 	private static final Logger log = LoggerFactory.getLogger(ExceptionAdvice.class);
+
+	public ExceptionAdvice(DiscordClient discordClient, Environment environment) {
+		this.discordClient = discordClient;
+		this.environment = environment;
+	}
 
 	@ExceptionHandler(value = CoreException.class)
 	public ResponseEntity<ErrorResponse> handleCoreException(CoreException e) {
@@ -60,9 +70,13 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
 	// exception 을 상속받는 모든 예외 처리
 	@ExceptionHandler(value = Exception.class)
-	public ResponseEntity<ErrorResponse> handleException(Exception e) {
+	public ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
 		log.error("[Exception] cause: {} , message: {}", NestedExceptionUtils.getMostSpecificCause(e), e.getMessage());
 		SystemErrorCode errorCode = SystemErrorCode.INTERNAL_SERVER_ERROR;
+		// if (!Arrays.asList(environment.getActiveProfiles()).contains("local")) {
+		// 	sendDiscordAlarm(e, request);
+		// }
+		sendDiscordAlarm(e, request);
 		return ResponseEntity
 			.status(errorCode.getHttpStatus())
 			.body(ErrorResponse.from(errorCode.getCode(), errorCode.getMessage()));
@@ -114,5 +128,10 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 			.status(errorCode.getHttpStatus())
 			.body(ErrorResponse.from(errorCode.getCode(), errorCode.getMessage(), errors));
 	}
-
+	
+	private void sendDiscordAlarm(Exception e, HttpServletRequest request) {
+		discordClient.sendAlarm(
+			DiscordMessage.fromException(e, request)
+		);
+	}
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/support/response/ExceptionAdvice.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/support/response/ExceptionAdvice.java
@@ -1,5 +1,6 @@
 package com.dongsan.api.support.response;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -73,10 +74,9 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 	public ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
 		log.error("[Exception] cause: {} , message: {}", NestedExceptionUtils.getMostSpecificCause(e), e.getMessage());
 		SystemErrorCode errorCode = SystemErrorCode.INTERNAL_SERVER_ERROR;
-		// if (!Arrays.asList(environment.getActiveProfiles()).contains("local")) {
-		// 	sendDiscordAlarm(e, request);
-		// }
-		sendDiscordAlarm(e, request);
+		if (!Arrays.asList(environment.getActiveProfiles()).contains("local")) {
+			sendDiscordAlarm(e, request);
+		}
 		return ResponseEntity
 			.status(errorCode.getHttpStatus())
 			.body(ErrorResponse.from(errorCode.getCode(), errorCode.getMessage()));
@@ -128,7 +128,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 			.status(errorCode.getHttpStatus())
 			.body(ErrorResponse.from(errorCode.getCode(), errorCode.getMessage(), errors));
 	}
-	
+
 	private void sendDiscordAlarm(Exception e, HttpServletRequest request) {
 		discordClient.sendAlarm(
 			DiscordMessage.fromException(e, request)

--- a/dongsan-external-api/src/main/java/com/dongsan/api/support/response/discord/DiscordClient.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/support/response/discord/DiscordClient.java
@@ -1,12 +1,14 @@
-package com.dongsan.api.support.response;
+package com.dongsan.api.support.response.discord;
 
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(
 	name = "discord-client",
 	url = "${discord.webhook.url}")
+@Profile("dev")
 public interface DiscordClient {
 	@PostMapping()
 	void sendAlarm(@RequestBody DiscordMessage message);

--- a/dongsan-external-api/src/main/java/com/dongsan/api/support/response/discord/DiscordMessage.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/support/response/discord/DiscordMessage.java
@@ -1,4 +1,4 @@
-package com.dongsan.api.support.response;
+package com.dongsan.api.support.response.discord;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/dongsan-external-api/src/main/java/com/dongsan/api/support/response/discord/DiscordNotifier.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/support/response/discord/DiscordNotifier.java
@@ -1,0 +1,9 @@
+package com.dongsan.api.support.response.discord;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public interface DiscordNotifier {
+    void notify(Exception e, HttpServletRequest request);
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/api/support/response/discord/DiscordNotifierDev.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/support/response/discord/DiscordNotifierDev.java
@@ -1,0 +1,22 @@
+package com.dongsan.api.support.response.discord;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("dev")
+public class DiscordNotifierDev implements DiscordNotifier {
+    private final DiscordClient discordClient;
+
+    public DiscordNotifierDev(DiscordClient discordClient) {
+        this.discordClient = discordClient;
+    }
+
+    @Override
+    public void notify(Exception e, HttpServletRequest request) {
+        discordClient.sendAlarm(
+                DiscordMessage.fromException(e, request)
+        );
+    }
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/api/support/response/discord/DiscordNotifierLocal.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/support/response/discord/DiscordNotifierLocal.java
@@ -1,0 +1,14 @@
+package com.dongsan.api.support.response.discord;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("local")
+public class DiscordNotifierLocal implements DiscordNotifier {
+    @Override
+    public void notify(Exception e, HttpServletRequest request) {
+
+    }
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/bookmark/BookmarkControllerTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/bookmark/BookmarkControllerTest.java
@@ -4,6 +4,7 @@ import com.dongsan.api.domains.auth.AuthUserDto;
 import com.dongsan.api.domains.auth.CustomAuthUser;
 import com.dongsan.api.domains.auth.oauth2.CustomRequestEntityConverter;
 import com.dongsan.api.support.response.CursorResponse;
+import com.dongsan.api.support.response.discord.DiscordNotifier;
 import com.dongsan.core.domains.bookmark.Bookmark;
 import com.dongsan.core.domains.bookmark.BookmarkService;
 import com.dongsan.core.domains.bookmark.MarkedWalkway;
@@ -50,6 +51,8 @@ class BookmarkControllerTest {
     BookmarkService bookmarkService;
     @MockBean
     CustomRequestEntityConverter customRequestEntityConverter;
+    @MockBean
+    DiscordNotifier discordNotifier;
 
     Member member;
     CustomAuthUser customOAuth2User;

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/member/MemberControllerTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/member/MemberControllerTest.java
@@ -3,6 +3,7 @@ package com.dongsan.api.domains.member;
 import com.dongsan.api.domains.auth.AuthUserDto;
 import com.dongsan.api.domains.auth.CustomAuthUser;
 import com.dongsan.api.domains.auth.oauth2.CustomRequestEntityConverter;
+import com.dongsan.api.support.response.discord.DiscordNotifier;
 import com.dongsan.core.domains.member.Member;
 import com.dongsan.core.domains.member.MemberService;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +38,9 @@ class MemberControllerTest {
 
     @MockBean
     CustomRequestEntityConverter customRequestEntityConverter;
+
+    @MockBean
+    DiscordNotifier discordNotifier;
 
     Member member;
 

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/review/ReviewControllerTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/review/ReviewControllerTest.java
@@ -3,6 +3,7 @@ package com.dongsan.api.domains.review;
 import com.dongsan.api.domains.auth.AuthUserDto;
 import com.dongsan.api.domains.auth.CustomAuthUser;
 import com.dongsan.api.domains.auth.oauth2.CustomRequestEntityConverter;
+import com.dongsan.api.support.response.discord.DiscordNotifier;
 import com.dongsan.core.domains.member.Member;
 import com.dongsan.core.domains.review.CreateReview;
 import com.dongsan.core.domains.review.Rating;
@@ -55,6 +56,8 @@ class ReviewControllerTest {
     ReviewService reviewService;
     @MockBean
     CustomRequestEntityConverter customRequestEntityConverter;
+    @MockBean
+    DiscordNotifier discordNotifier;
 
     final Member member = MemberFixture.createMember();
     final CustomAuthUser customOAuth2User = new CustomAuthUser(new AuthUserDto(member));

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/review/UserReviewControllerTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/review/UserReviewControllerTest.java
@@ -3,6 +3,7 @@ package com.dongsan.api.domains.review;
 import com.dongsan.api.domains.auth.AuthUserDto;
 import com.dongsan.api.domains.auth.CustomAuthUser;
 import com.dongsan.api.domains.auth.oauth2.CustomRequestEntityConverter;
+import com.dongsan.api.support.response.discord.DiscordNotifier;
 import com.dongsan.core.domains.member.Member;
 import com.dongsan.core.domains.review.Review;
 import com.dongsan.core.domains.review.ReviewReader;
@@ -51,6 +52,8 @@ class UserReviewControllerTest {
     UserReviewService userReviewService;
     @MockBean
     ReviewReader reviewReader;
+    @MockBean
+    DiscordNotifier discordNotifier;
     final Member member = createMember();
     final CustomAuthUser customOAuth2User = new CustomAuthUser(new AuthUserDto(member));
 

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/walkway/LikedWalkwayControllerTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/walkway/LikedWalkwayControllerTest.java
@@ -3,6 +3,7 @@ package com.dongsan.api.domains.walkway;
 import com.dongsan.api.domains.auth.AuthUserDto;
 import com.dongsan.api.domains.auth.CustomAuthUser;
 import com.dongsan.api.domains.auth.oauth2.CustomRequestEntityConverter;
+import com.dongsan.api.support.response.discord.DiscordNotifier;
 import com.dongsan.core.domains.member.Member;
 import com.dongsan.core.domains.walkway.WalkwayService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,6 +43,9 @@ class LikedWalkwayControllerTest {
     ObjectMapper objectMapper;
     @MockBean
     WalkwayService walkwayService;
+    @MockBean
+    DiscordNotifier discordNotifier;
+
     final Member member = createMember();
     final CustomAuthUser customOAuth2User = new CustomAuthUser(new AuthUserDto(member));
 

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/walkway/UserWalkwayControllerTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/walkway/UserWalkwayControllerTest.java
@@ -3,6 +3,7 @@ package com.dongsan.api.domains.walkway;
 import com.dongsan.api.domains.auth.AuthUserDto;
 import com.dongsan.api.domains.auth.CustomAuthUser;
 import com.dongsan.api.domains.auth.oauth2.CustomRequestEntityConverter;
+import com.dongsan.api.support.response.discord.DiscordNotifier;
 import com.dongsan.core.domains.member.Member;
 import com.dongsan.core.domains.walkway.Walkway;
 import com.dongsan.core.domains.walkway.WalkwayHistory;
@@ -49,6 +50,8 @@ class UserWalkwayControllerTest {
     CustomRequestEntityConverter customRequestEntityConverter;
     @MockBean
     WalkwayService walkwayService;
+    @MockBean
+    DiscordNotifier discordNotifier;
 
     final Member member = createMember();
     final CustomAuthUser customOAuth2User = new CustomAuthUser(new AuthUserDto(member));

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/walkway/WalkwayControllerTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/walkway/WalkwayControllerTest.java
@@ -9,6 +9,7 @@ import com.dongsan.api.domains.walkway.dto.request.CreateWalkwayHistoryRequest;
 import com.dongsan.api.domains.walkway.dto.request.CreateWalkwayRequest;
 import com.dongsan.api.domains.walkway.dto.request.UpdateWalkwayRequest;
 import com.dongsan.api.support.error.ApiErrorCode;
+import com.dongsan.api.support.response.discord.DiscordNotifier;
 import com.dongsan.core.domains.bookmark.BookmarkService;
 import com.dongsan.core.domains.bookmark.BookmarkWithMarkedStatus;
 import com.dongsan.core.domains.image.Image;
@@ -79,6 +80,9 @@ class WalkwayControllerTest {
 
     @MockBean
     ImageService imageService;
+
+    @MockBean
+    DiscordNotifier discordNotifier;
 
     final Member member = createMember();
     final CustomAuthUser customOAuth2User = new CustomAuthUser(new AuthUserDto(member));


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

## 📄 Work Description
<strong>Jira Ticket : `DB-253`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. 디스코드 알람 구현
![image](https://github.com/user-attachments/assets/cb02244a-b2a3-4e71-a760-baf5b4502515)
![image](https://github.com/user-attachments/assets/9b39f677-d504-4b04-8114-a572275758df)
![image](https://github.com/user-attachments/assets/f3d7b8a4-fa2a-451e-920f-585d37b17550)
![image](https://github.com/user-attachments/assets/9ffaa10e-42f1-4236-b03f-6a2416a04a3e)
![image](https://github.com/user-attachments/assets/19e42cb6-dbf5-4f96-b0bd-0edfc6d77638)
Feign을 사용해 구현
인터페이스를 사용해 사용

#### 2. advice 수정
![image](https://github.com/user-attachments/assets/85486a12-a99d-4a65-a6fd-e7ea1543a1ee)

에러 알람에 요청한 URL을 넣기 위해 HttpServletRequest를 추가함
`discordNotifier.notify(e, request);`
통해 알람 전송

#### 3. test 수정
![image](https://github.com/user-attachments/assets/cbe81388-28e0-4bb7-86c4-3d54171820ef)
DiscordNotifier를 MockBean으로 추가
<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->


<br/>

## 🔗 Reference
[//]: # (문제를 해결하면서 도움이 되었거나 참고했던 사이트 또는 코드 첨부)
