### PR TITLE
[feature/DB-286]: 같이산책 생성, 조회, 참여 API

### DIFF
--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/CreateCowalkPostCommand.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/CreateCowalkPostCommand.java
@@ -4,10 +4,10 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 public record CreateCowalkPostCommand(
-	Long crewId,
-	Long memberId,
-	LocalDate date,
-	LocalTime time,
-	Integer capacity
+        Long crewId,
+        Long memberId,
+        LocalDate date,
+        LocalTime time,
+        Integer capacity
 ) {
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/CreateCowalkPostCommand.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/CreateCowalkPostCommand.java
@@ -1,0 +1,13 @@
+package com.dongsan.domain.domains.cowalk;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record CreateCowalkPostCommand(
+	Long crewId,
+	Long memberId,
+	LocalDate date,
+	LocalTime time,
+	Integer capacity
+) {
+}

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CapacityType.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CapacityType.java
@@ -1,6 +1,6 @@
 package com.dongsan.domain.domains.cowalk.domain;
 
 public enum CapacityType {
-	LIMITED,
-	UNLIMITED
+    LIMITED,
+    UNLIMITED
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CapacityType.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CapacityType.java
@@ -1,0 +1,6 @@
+package com.dongsan.domain.domains.cowalk.domain;
+
+public enum CapacityType {
+	LIMITED,
+	UNLIMITED
+}

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkComment.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkComment.java
@@ -1,7 +1,12 @@
 package com.dongsan.domain.domains.cowalk.domain;
 
 import com.dongsan.domain.domains.common.BaseEntity;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "cowalk_comment")

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkCommentRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkCommentRepository.java
@@ -3,8 +3,6 @@ package com.dongsan.domain.domains.cowalk.domain;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CowalkParticipantRepository {
-	CowalkParticipant save(CowalkParticipant cowalkParticipant);
-
+public interface CowalkCommentRepository {
 	Integer countByCowalkPostId(Long cowalkPostId);
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkCommentRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkCommentRepository.java
@@ -1,8 +1,13 @@
 package com.dongsan.domain.domains.cowalk.domain;
 
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CowalkCommentRepository {
 	Integer countByCowalkPostId(Long cowalkPostId);
+
+	Map<Long, Integer> countByCowalkPostIds(List<Long> cowalkPostIds);
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkCommentRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkCommentRepository.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CowalkCommentRepository {
-	Integer countByCowalkPostId(Long cowalkPostId);
+    Integer countByCowalkPostId(Long cowalkPostId);
 
-	Map<Long, Integer> countByCowalkPostIds(List<Long> cowalkPostIds);
+    Map<Long, Integer> countByCowalkPostIds(List<Long> cowalkPostIds);
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkParticipant.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkParticipant.java
@@ -1,19 +1,33 @@
 package com.dongsan.domain.domains.cowalk.domain;
 
 import com.dongsan.domain.domains.common.BaseEntity;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "cowalk_participant")
 public class CowalkParticipant extends BaseEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    private Long cowalkPostId;
+	private Long cowalkPostId;
 
-    private Long memberId;
+	private Long memberId;
 
-    protected CowalkParticipant() {
-    }
+	protected CowalkParticipant() {
+	}
+
+	public CowalkParticipant(Long cowalkPostId, Long memberId) {
+		this.cowalkPostId = cowalkPostId;
+		this.memberId = memberId;
+	}
+
+	public Long getId() {
+		return id;
+	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkParticipant.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkParticipant.java
@@ -11,23 +11,23 @@ import jakarta.persistence.Table;
 @Entity
 @Table(name = "cowalk_participant")
 public class CowalkParticipant extends BaseEntity {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	private Long cowalkPostId;
+    private Long cowalkPostId;
 
-	private Long memberId;
+    private Long memberId;
 
-	protected CowalkParticipant() {
-	}
+    protected CowalkParticipant() {
+    }
 
-	public CowalkParticipant(Long cowalkPostId, Long memberId) {
-		this.cowalkPostId = cowalkPostId;
-		this.memberId = memberId;
-	}
+    public CowalkParticipant(Long cowalkPostId, Long memberId) {
+        this.cowalkPostId = cowalkPostId;
+        this.memberId = memberId;
+    }
 
-	public Long getId() {
-		return id;
-	}
+    public Long getId() {
+        return id;
+    }
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkParticipantRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkParticipantRepository.java
@@ -1,5 +1,8 @@
 package com.dongsan.domain.domains.cowalk.domain;
 
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -9,4 +12,6 @@ public interface CowalkParticipantRepository {
 	Integer countByCowalkPostId(Long cowalkPostId);
 
 	Boolean existsByMemberIdAndCowalkPostId(Long memberId, Long cowalkPostId);
+
+	Map<Long, Integer> countByCowalkPostIds(List<Long> cowalkPostIds);
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkParticipantRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkParticipantRepository.java
@@ -7,11 +7,11 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CowalkParticipantRepository {
-	CowalkParticipant save(CowalkParticipant cowalkParticipant);
+    CowalkParticipant save(CowalkParticipant cowalkParticipant);
 
-	Integer countByCowalkPostId(Long cowalkPostId);
+    Integer countByCowalkPostId(Long cowalkPostId);
 
-	Boolean existsByMemberIdAndCowalkPostId(Long memberId, Long cowalkPostId);
+    Boolean existsByMemberIdAndCowalkPostId(Long memberId, Long cowalkPostId);
 
-	Map<Long, Integer> countByCowalkPostIds(List<Long> cowalkPostIds);
+    Map<Long, Integer> countByCowalkPostIds(List<Long> cowalkPostIds);
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkParticipantRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkParticipantRepository.java
@@ -1,0 +1,8 @@
+package com.dongsan.domain.domains.cowalk.domain;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CowalkParticipantRepository {
+	public CowalkParticipant save(CowalkParticipant cowalkParticipant);
+}

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkParticipantRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkParticipantRepository.java
@@ -7,4 +7,6 @@ public interface CowalkParticipantRepository {
 	CowalkParticipant save(CowalkParticipant cowalkParticipant);
 
 	Integer countByCowalkPostId(Long cowalkPostId);
+
+	Boolean existsByMemberIdAndCowalkPostId(Long memberId, Long cowalkPostId);
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
@@ -1,28 +1,46 @@
 package com.dongsan.domain.domains.cowalk.domain;
 
-import com.dongsan.domain.domains.common.BaseEntity;
-import jakarta.persistence.*;
-
 import java.time.LocalDate;
 import java.time.LocalTime;
+
+import com.dongsan.domain.domains.common.BaseEntity;
+import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "cowalk_post")
 public class CowalkPost extends BaseEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    private Long crewId;
+	private Long crewId;
 
-    private Long memberId;
+	private Long memberId;
 
-    private LocalDate date;
+	private LocalDate date;
 
-    private LocalTime time;
+	private LocalTime time;
 
-    private Integer capacity;
+	private Integer capacity;
 
-    protected CowalkPost() {
-    }
+	protected CowalkPost() {
+	}
+
+	public CowalkPost(CreateCowalkPostCommand command) {
+		this.crewId = command.crewId();
+		this.memberId = command.memberId();
+		this.date = command.date();
+		this.time = command.time();
+		this.capacity = command.capacity();
+	}
+
+	public Long getId() {
+		return id;
+	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
@@ -20,65 +20,65 @@ import jakarta.persistence.Table;
 @Entity
 @Table(name = "cowalk_post")
 public class CowalkPost extends BaseEntity {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	private Long crewId;
+    private Long crewId;
 
-	private Long memberId;
+    private Long memberId;
 
-	private LocalDate date;
+    private LocalDate date;
 
-	private LocalTime time;
+    private LocalTime time;
 
-	private Integer capacity;
+    private Integer capacity;
 
-	@Enumerated(EnumType.STRING)
-	private CapacityType capacityType;
+    @Enumerated(EnumType.STRING)
+    private CapacityType capacityType;
 
-	protected CowalkPost() {
-	}
+    protected CowalkPost() {
+    }
 
-	public CowalkPost(CreateCowalkPostCommand command) {
-		this.crewId = command.crewId();
-		this.memberId = command.memberId();
-		this.date = command.date();
-		this.time = command.time();
-		this.capacity = command.capacity();
-		this.capacityType = command.capacity() == null ? CapacityType.UNLIMITED : CapacityType.LIMITED;
-	}
+    public CowalkPost(CreateCowalkPostCommand command) {
+        this.crewId = command.crewId();
+        this.memberId = command.memberId();
+        this.date = command.date();
+        this.time = command.time();
+        this.capacity = command.capacity();
+        this.capacityType = command.capacity() == null ? CapacityType.UNLIMITED : CapacityType.LIMITED;
+    }
 
-	public void validCapacity(Integer participantCount) {
-		if (capacityType.equals(CapacityType.UNLIMITED))
-			return;
+    public void validCapacity(Integer participantCount) {
+        if (capacityType.equals(CapacityType.UNLIMITED))
+            return;
 
-		if (participantCount >= capacity) {
-			throw new CoreException(COWALK_PARTICIPANT_LIMIT);
-		}
-	}
+        if (participantCount >= capacity) {
+            throw new CoreException(COWALK_PARTICIPANT_LIMIT);
+        }
+    }
 
-	public Long getId() {
-		return id;
-	}
+    public Long getId() {
+        return id;
+    }
 
-	public Long getMemberId() {
-		return memberId;
-	}
+    public Long getMemberId() {
+        return memberId;
+    }
 
-	public LocalDate getDate() {
-		return date;
-	}
+    public LocalDate getDate() {
+        return date;
+    }
 
-	public LocalTime getTime() {
-		return time;
-	}
+    public LocalTime getTime() {
+        return time;
+    }
 
-	public Integer getCapacity() {
-		return capacity;
-	}
+    public Integer getCapacity() {
+        return capacity;
+    }
 
-	public CapacityType getCapacityType() {
-		return capacityType;
-	}
+    public CapacityType getCapacityType() {
+        return capacityType;
+    }
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
@@ -1,10 +1,13 @@
 package com.dongsan.domain.domains.cowalk.domain;
 
+import static com.dongsan.domain.support.error.CoreErrorCode.*;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 
 import com.dongsan.domain.domains.common.BaseEntity;
 import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
+import com.dongsan.domain.support.error.CoreException;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -38,6 +41,12 @@ public class CowalkPost extends BaseEntity {
 		this.date = command.date();
 		this.time = command.time();
 		this.capacity = command.capacity();
+	}
+
+	public void validCapacity(Integer participantCount) {
+		if (participantCount >= capacity) {
+			throw new CoreException(COWALK_PARTICIPANT_LIMIT);
+		}
 	}
 
 	public Long getId() {

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
@@ -50,7 +50,10 @@ public class CowalkPost extends BaseEntity {
 	}
 
 	public void validCapacity(Integer participantCount) {
-		if (capacityType.equals(CapacityType.LIMITED) && participantCount >= capacity) {
+		if (capacityType.equals(CapacityType.UNLIMITED))
+			return;
+
+		if (participantCount >= capacity) {
 			throw new CoreException(COWALK_PARTICIPANT_LIMIT);
 		}
 	}

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
@@ -43,4 +43,20 @@ public class CowalkPost extends BaseEntity {
 	public Long getId() {
 		return id;
 	}
+
+	public Long getMemberId() {
+		return memberId;
+	}
+
+	public LocalDate getDate() {
+		return date;
+	}
+
+	public LocalTime getTime() {
+		return time;
+	}
+
+	public Integer getCapacity() {
+		return capacity;
+	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
@@ -10,6 +10,8 @@ import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
 import com.dongsan.domain.support.error.CoreException;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -32,6 +34,9 @@ public class CowalkPost extends BaseEntity {
 
 	private Integer capacity;
 
+	@Enumerated(EnumType.STRING)
+	private CapacityType capacityType;
+
 	protected CowalkPost() {
 	}
 
@@ -41,10 +46,11 @@ public class CowalkPost extends BaseEntity {
 		this.date = command.date();
 		this.time = command.time();
 		this.capacity = command.capacity();
+		this.capacityType = command.capacity() == null ? CapacityType.UNLIMITED : CapacityType.LIMITED;
 	}
 
 	public void validCapacity(Integer participantCount) {
-		if (participantCount >= capacity) {
+		if (capacityType.equals(CapacityType.LIMITED) && participantCount >= capacity) {
 			throw new CoreException(COWALK_PARTICIPANT_LIMIT);
 		}
 	}
@@ -67,5 +73,9 @@ public class CowalkPost extends BaseEntity {
 
 	public Integer getCapacity() {
 		return capacity;
+	}
+
+	public CapacityType getCapacityType() {
+		return capacityType;
 	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPostRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPostRepository.java
@@ -8,9 +8,9 @@ import com.dongsan.domain.support.util.CursorPage;
 
 @Repository
 public interface CowalkPostRepository {
-	void save(CowalkPost cowalkPost);
+    void save(CowalkPost cowalkPost);
 
-	Optional<CowalkPost> findById(Long id);
+    Optional<CowalkPost> findById(Long id);
 
-	CursorPage<CowalkPost> getCowalkPosts(Integer size, Long lastId, Long crewId);
+    CursorPage<CowalkPost> getCowalkPosts(Integer size, Long lastId, Long crewId);
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPostRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPostRepository.java
@@ -1,0 +1,8 @@
+package com.dongsan.domain.domains.cowalk.domain;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CowalkPostRepository {
+	void save(CowalkPost cowalkPost);
+}

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPostRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPostRepository.java
@@ -4,9 +4,13 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import com.dongsan.domain.support.util.CursorPage;
+
 @Repository
 public interface CowalkPostRepository {
 	void save(CowalkPost cowalkPost);
 
 	Optional<CowalkPost> findById(Long id);
+
+	CursorPage<CowalkPost> getCowalkPosts(Integer size, Long lastId, Long crewId);
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPostRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPostRepository.java
@@ -1,8 +1,12 @@
 package com.dongsan.domain.domains.cowalk.domain;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CowalkPostRepository {
 	void save(CowalkPost cowalkPost);
+
+	Optional<CowalkPost> findById(Long id);
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkCommentCoreRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkCommentCoreRepository.java
@@ -13,37 +13,37 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 @Repository
 public class CowalkCommentCoreRepository implements CowalkCommentRepository {
-	private final CowalkCommentJpaRepository cowalkCommentJpaRepository;
-	private final JPAQueryFactory queryFactory;
+    private final CowalkCommentJpaRepository cowalkCommentJpaRepository;
+    private final JPAQueryFactory queryFactory;
 
-	private final QCowalkComment cowalkComment = QCowalkComment.cowalkComment;
+    private final QCowalkComment cowalkComment = QCowalkComment.cowalkComment;
 
-	public CowalkCommentCoreRepository(
-		CowalkCommentJpaRepository cowalkCommentJpaRepository,
-		JPAQueryFactory queryFactory
-	) {
-		this.cowalkCommentJpaRepository = cowalkCommentJpaRepository;
-		this.queryFactory = queryFactory;
-	}
+    public CowalkCommentCoreRepository(
+            CowalkCommentJpaRepository cowalkCommentJpaRepository,
+            JPAQueryFactory queryFactory
+    ) {
+        this.cowalkCommentJpaRepository = cowalkCommentJpaRepository;
+        this.queryFactory = queryFactory;
+    }
 
-	@Override
-	public Integer countByCowalkPostId(Long cowalkPostId) {
-		return cowalkCommentJpaRepository.countByCowalkPostId(cowalkPostId);
-	}
+    @Override
+    public Integer countByCowalkPostId(Long cowalkPostId) {
+        return cowalkCommentJpaRepository.countByCowalkPostId(cowalkPostId);
+    }
 
-	@Override
-	public Map<Long, Integer> countByCowalkPostIds(List<Long> cowalkPostIds) {
-		List<Tuple> countTuple = queryFactory
-			.select(cowalkComment.cowalkPostId, cowalkComment.count())
-			.from(cowalkComment)
-			.where(cowalkComment.cowalkPostId.in(cowalkPostIds))
-			.groupBy(cowalkComment.cowalkPostId)
-			.fetch();
+    @Override
+    public Map<Long, Integer> countByCowalkPostIds(List<Long> cowalkPostIds) {
+        List<Tuple> countTuple = queryFactory
+                .select(cowalkComment.cowalkPostId, cowalkComment.count())
+                .from(cowalkComment)
+                .where(cowalkComment.cowalkPostId.in(cowalkPostIds))
+                .groupBy(cowalkComment.cowalkPostId)
+                .fetch();
 
-		return countTuple.stream()
-			.collect(Collectors.toMap(
-				tuple -> tuple.get(cowalkComment.cowalkPostId),
-				tuple -> tuple.get(cowalkComment.count()).intValue()
-			));
-	}
+        return countTuple.stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(cowalkComment.cowalkPostId),
+                        tuple -> tuple.get(cowalkComment.count()).intValue()
+                ));
+    }
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkCommentCoreRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkCommentCoreRepository.java
@@ -1,19 +1,49 @@
 package com.dongsan.domain.domains.cowalk.infrastructure;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Repository;
 
 import com.dongsan.domain.domains.cowalk.domain.CowalkCommentRepository;
+import com.dongsan.domain.domains.cowalk.domain.QCowalkComment;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 
 @Repository
 public class CowalkCommentCoreRepository implements CowalkCommentRepository {
 	private final CowalkCommentJpaRepository cowalkCommentJpaRepository;
+	private final JPAQueryFactory queryFactory;
 
-	public CowalkCommentCoreRepository(CowalkCommentJpaRepository cowalkCommentJpaRepository) {
+	private final QCowalkComment cowalkComment = QCowalkComment.cowalkComment;
+
+	public CowalkCommentCoreRepository(
+		CowalkCommentJpaRepository cowalkCommentJpaRepository,
+		JPAQueryFactory queryFactory
+	) {
 		this.cowalkCommentJpaRepository = cowalkCommentJpaRepository;
+		this.queryFactory = queryFactory;
 	}
 
 	@Override
 	public Integer countByCowalkPostId(Long cowalkPostId) {
 		return cowalkCommentJpaRepository.countByCowalkPostId(cowalkPostId);
+	}
+
+	@Override
+	public Map<Long, Integer> countByCowalkPostIds(List<Long> cowalkPostIds) {
+		List<Tuple> countTuple = queryFactory
+			.select(cowalkComment.cowalkPostId, cowalkComment.count())
+			.from(cowalkComment)
+			.where(cowalkComment.cowalkPostId.in(cowalkPostIds))
+			.groupBy(cowalkComment.cowalkPostId)
+			.fetch();
+
+		return countTuple.stream()
+			.collect(Collectors.toMap(
+				tuple -> tuple.get(cowalkComment.cowalkPostId),
+				tuple -> tuple.get(cowalkComment.count()).intValue()
+			));
 	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkCommentCoreRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkCommentCoreRepository.java
@@ -1,0 +1,19 @@
+package com.dongsan.domain.domains.cowalk.infrastructure;
+
+import org.springframework.stereotype.Repository;
+
+import com.dongsan.domain.domains.cowalk.domain.CowalkCommentRepository;
+
+@Repository
+public class CowalkCommentCoreRepository implements CowalkCommentRepository {
+	private final CowalkCommentJpaRepository cowalkCommentJpaRepository;
+
+	public CowalkCommentCoreRepository(CowalkCommentJpaRepository cowalkCommentJpaRepository) {
+		this.cowalkCommentJpaRepository = cowalkCommentJpaRepository;
+	}
+
+	@Override
+	public Integer countByCowalkPostId(Long cowalkPostId) {
+		return cowalkCommentJpaRepository.countByCowalkPostId(cowalkPostId);
+	}
+}

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkCommentJpaRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkCommentJpaRepository.java
@@ -7,5 +7,5 @@ import com.dongsan.domain.domains.cowalk.domain.CowalkComment;
 
 @Repository
 public interface CowalkCommentJpaRepository extends JpaRepository<CowalkComment, Long> {
-	Integer countByCowalkPostId(Long cowalkPostId);
+    Integer countByCowalkPostId(Long cowalkPostId);
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkCommentJpaRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkCommentJpaRepository.java
@@ -3,9 +3,9 @@ package com.dongsan.domain.domains.cowalk.infrastructure;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import com.dongsan.domain.domains.cowalk.domain.CowalkParticipant;
+import com.dongsan.domain.domains.cowalk.domain.CowalkComment;
 
 @Repository
-public interface CowalkParticipantJpaRepository extends JpaRepository<CowalkParticipant, Long> {
+public interface CowalkCommentJpaRepository extends JpaRepository<CowalkComment, Long> {
 	Integer countByCowalkPostId(Long cowalkPostId);
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkParticipantCoreRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkParticipantCoreRepository.java
@@ -14,46 +14,46 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 @Repository
 public class CowalkParticipantCoreRepository implements CowalkParticipantRepository {
-	private final CowalkParticipantJpaRepository cowalkParticipantJpaRepository;
-	private final JPAQueryFactory queryFactory;
+    private final CowalkParticipantJpaRepository cowalkParticipantJpaRepository;
+    private final JPAQueryFactory queryFactory;
 
-	private final QCowalkParticipant cowalkParticipant = QCowalkParticipant.cowalkParticipant;
+    private final QCowalkParticipant cowalkParticipant = QCowalkParticipant.cowalkParticipant;
 
-	public CowalkParticipantCoreRepository(
-		CowalkParticipantJpaRepository cowalkParticipantJpaRepository,
-		JPAQueryFactory queryFactory
-	) {
-		this.cowalkParticipantJpaRepository = cowalkParticipantJpaRepository;
-		this.queryFactory = queryFactory;
-	}
+    public CowalkParticipantCoreRepository(
+            CowalkParticipantJpaRepository cowalkParticipantJpaRepository,
+            JPAQueryFactory queryFactory
+    ) {
+        this.cowalkParticipantJpaRepository = cowalkParticipantJpaRepository;
+        this.queryFactory = queryFactory;
+    }
 
-	@Override
-	public CowalkParticipant save(CowalkParticipant cowalkParticipant) {
-		return cowalkParticipantJpaRepository.save(cowalkParticipant);
-	}
+    @Override
+    public CowalkParticipant save(CowalkParticipant cowalkParticipant) {
+        return cowalkParticipantJpaRepository.save(cowalkParticipant);
+    }
 
-	@Override
-	public Integer countByCowalkPostId(Long cowalkPostId) {
-		return cowalkParticipantJpaRepository.countByCowalkPostId(cowalkPostId);
-	}
+    @Override
+    public Integer countByCowalkPostId(Long cowalkPostId) {
+        return cowalkParticipantJpaRepository.countByCowalkPostId(cowalkPostId);
+    }
 
-	@Override
-	public Boolean existsByMemberIdAndCowalkPostId(Long memberId, Long cowalkPostId) {
-		return cowalkParticipantJpaRepository.existsByMemberIdAndCowalkPostId(memberId, cowalkPostId);
-	}
+    @Override
+    public Boolean existsByMemberIdAndCowalkPostId(Long memberId, Long cowalkPostId) {
+        return cowalkParticipantJpaRepository.existsByMemberIdAndCowalkPostId(memberId, cowalkPostId);
+    }
 
-	public Map<Long, Integer> countByCowalkPostIds(List<Long> cowalkPostIds) {
-		List<Tuple> countTuple = queryFactory
-			.select(cowalkParticipant.cowalkPostId, cowalkParticipant.count())
-			.from(cowalkParticipant)
-			.where(cowalkParticipant.cowalkPostId.in(cowalkPostIds))
-			.groupBy(cowalkParticipant.cowalkPostId)
-			.fetch();
+    public Map<Long, Integer> countByCowalkPostIds(List<Long> cowalkPostIds) {
+        List<Tuple> countTuple = queryFactory
+                .select(cowalkParticipant.cowalkPostId, cowalkParticipant.count())
+                .from(cowalkParticipant)
+                .where(cowalkParticipant.cowalkPostId.in(cowalkPostIds))
+                .groupBy(cowalkParticipant.cowalkPostId)
+                .fetch();
 
-		return countTuple.stream()
-			.collect(Collectors.toMap(
-				tuple -> tuple.get(cowalkParticipant.cowalkPostId),
-				tuple -> tuple.get(cowalkParticipant.count()).intValue()
-			));
-	}
+        return countTuple.stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(cowalkParticipant.cowalkPostId),
+                        tuple -> tuple.get(cowalkParticipant.count()).intValue()
+                ));
+    }
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkParticipantCoreRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkParticipantCoreRepository.java
@@ -1,0 +1,20 @@
+package com.dongsan.domain.domains.cowalk.infrastructure;
+
+import org.springframework.stereotype.Repository;
+
+import com.dongsan.domain.domains.cowalk.domain.CowalkParticipant;
+import com.dongsan.domain.domains.cowalk.domain.CowalkParticipantRepository;
+
+@Repository
+public class CowalkParticipantCoreRepository implements CowalkParticipantRepository {
+	private final CowalkParticipantJpaRepository cowalkParticipantJpaRepository;
+
+	public CowalkParticipantCoreRepository(CowalkParticipantJpaRepository cowalkParticipantJpaRepository) {
+		this.cowalkParticipantJpaRepository = cowalkParticipantJpaRepository;
+	}
+
+	@Override
+	public CowalkParticipant save(CowalkParticipant cowalkParticipant) {
+		return cowalkParticipantJpaRepository.save(cowalkParticipant);
+	}
+}

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkParticipantCoreRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkParticipantCoreRepository.java
@@ -22,4 +22,9 @@ public class CowalkParticipantCoreRepository implements CowalkParticipantReposit
 	public Integer countByCowalkPostId(Long cowalkPostId) {
 		return cowalkParticipantJpaRepository.countByCowalkPostId(cowalkPostId);
 	}
+
+	@Override
+	public Boolean existsByMemberIdAndCowalkPostId(Long memberId, Long cowalkPostId) {
+		return cowalkParticipantJpaRepository.existsByMemberIdAndCowalkPostId(memberId, cowalkPostId);
+	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkParticipantCoreRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkParticipantCoreRepository.java
@@ -17,4 +17,9 @@ public class CowalkParticipantCoreRepository implements CowalkParticipantReposit
 	public CowalkParticipant save(CowalkParticipant cowalkParticipant) {
 		return cowalkParticipantJpaRepository.save(cowalkParticipant);
 	}
+
+	@Override
+	public Integer countByCowalkPostId(Long cowalkPostId) {
+		return cowalkParticipantJpaRepository.countByCowalkPostId(cowalkPostId);
+	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkParticipantCoreRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkParticipantCoreRepository.java
@@ -1,16 +1,30 @@
 package com.dongsan.domain.domains.cowalk.infrastructure;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Repository;
 
 import com.dongsan.domain.domains.cowalk.domain.CowalkParticipant;
 import com.dongsan.domain.domains.cowalk.domain.CowalkParticipantRepository;
+import com.dongsan.domain.domains.cowalk.domain.QCowalkParticipant;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 
 @Repository
 public class CowalkParticipantCoreRepository implements CowalkParticipantRepository {
 	private final CowalkParticipantJpaRepository cowalkParticipantJpaRepository;
+	private final JPAQueryFactory queryFactory;
 
-	public CowalkParticipantCoreRepository(CowalkParticipantJpaRepository cowalkParticipantJpaRepository) {
+	private final QCowalkParticipant cowalkParticipant = QCowalkParticipant.cowalkParticipant;
+
+	public CowalkParticipantCoreRepository(
+		CowalkParticipantJpaRepository cowalkParticipantJpaRepository,
+		JPAQueryFactory queryFactory
+	) {
 		this.cowalkParticipantJpaRepository = cowalkParticipantJpaRepository;
+		this.queryFactory = queryFactory;
 	}
 
 	@Override
@@ -26,5 +40,20 @@ public class CowalkParticipantCoreRepository implements CowalkParticipantReposit
 	@Override
 	public Boolean existsByMemberIdAndCowalkPostId(Long memberId, Long cowalkPostId) {
 		return cowalkParticipantJpaRepository.existsByMemberIdAndCowalkPostId(memberId, cowalkPostId);
+	}
+
+	public Map<Long, Integer> countByCowalkPostIds(List<Long> cowalkPostIds) {
+		List<Tuple> countTuple = queryFactory
+			.select(cowalkParticipant.cowalkPostId, cowalkParticipant.count())
+			.from(cowalkParticipant)
+			.where(cowalkParticipant.cowalkPostId.in(cowalkPostIds))
+			.groupBy(cowalkParticipant.cowalkPostId)
+			.fetch();
+
+		return countTuple.stream()
+			.collect(Collectors.toMap(
+				tuple -> tuple.get(cowalkParticipant.cowalkPostId),
+				tuple -> tuple.get(cowalkParticipant.count()).intValue()
+			));
 	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkParticipantJpaRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkParticipantJpaRepository.java
@@ -8,4 +8,6 @@ import com.dongsan.domain.domains.cowalk.domain.CowalkParticipant;
 @Repository
 public interface CowalkParticipantJpaRepository extends JpaRepository<CowalkParticipant, Long> {
 	Integer countByCowalkPostId(Long cowalkPostId);
+
+	Boolean existsByMemberIdAndCowalkPostId(Long memberId, Long cowalkPostId);
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkParticipantJpaRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkParticipantJpaRepository.java
@@ -7,7 +7,7 @@ import com.dongsan.domain.domains.cowalk.domain.CowalkParticipant;
 
 @Repository
 public interface CowalkParticipantJpaRepository extends JpaRepository<CowalkParticipant, Long> {
-	Integer countByCowalkPostId(Long cowalkPostId);
+    Integer countByCowalkPostId(Long cowalkPostId);
 
-	Boolean existsByMemberIdAndCowalkPostId(Long memberId, Long cowalkPostId);
+    Boolean existsByMemberIdAndCowalkPostId(Long memberId, Long cowalkPostId);
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkParticipantJpaRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkParticipantJpaRepository.java
@@ -1,0 +1,10 @@
+package com.dongsan.domain.domains.cowalk.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.dongsan.domain.domains.cowalk.domain.CowalkParticipant;
+
+@Repository
+public interface CowalkParticipantJpaRepository extends JpaRepository<CowalkParticipant, Long> {
+}

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkPostCoreRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkPostCoreRepository.java
@@ -1,5 +1,6 @@
 package com.dongsan.domain.domains.cowalk.infrastructure;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
@@ -7,6 +8,8 @@ import org.springframework.stereotype.Repository;
 import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
 import com.dongsan.domain.domains.cowalk.domain.CowalkPostRepository;
 import com.dongsan.domain.domains.cowalk.domain.QCowalkPost;
+import com.dongsan.domain.support.util.CursorPage;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 @Repository
@@ -15,7 +18,7 @@ public class CowalkPostCoreRepository implements CowalkPostRepository {
 	private final CowalkPostJpaRepository cowalkPostJpaRepository;
 	private final JPAQueryFactory queryFactory;
 
-	private final QCowalkPost qCowalkPost = QCowalkPost.cowalkPost;
+	private final QCowalkPost cowalkPost = QCowalkPost.cowalkPost;
 
 	public CowalkPostCoreRepository(CowalkPostJpaRepository cowalkPostJpaRepository, JPAQueryFactory queryFactory) {
 		this.cowalkPostJpaRepository = cowalkPostJpaRepository;
@@ -30,5 +33,23 @@ public class CowalkPostCoreRepository implements CowalkPostRepository {
 	@Override
 	public Optional<CowalkPost> findById(Long id) {
 		return cowalkPostJpaRepository.findById(id);
+	}
+
+	@Override
+	public CursorPage<CowalkPost> getCowalkPosts(Integer size, Long lastId, Long crewId) {
+		List<CowalkPost> cowalkPosts = queryFactory.selectFrom(cowalkPost)
+			.where(
+				cowalkPost.crewId.eq(crewId),
+				cowalkPostIdLt(lastId)
+			)
+			.orderBy(cowalkPost.id.desc())
+			.limit(size + 1L)
+			.fetch();
+
+		return new CursorPage<>(cowalkPosts, size);
+	}
+
+	private BooleanExpression cowalkPostIdLt(Long id) {
+		return id == null ? null : cowalkPost.id.lt(id);
 	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkPostCoreRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkPostCoreRepository.java
@@ -1,5 +1,7 @@
 package com.dongsan.domain.domains.cowalk.infrastructure;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Repository;
 
 import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
@@ -23,5 +25,10 @@ public class CowalkPostCoreRepository implements CowalkPostRepository {
 	@Override
 	public void save(CowalkPost cowalkPost) {
 		cowalkPostJpaRepository.save(cowalkPost);
+	}
+
+	@Override
+	public Optional<CowalkPost> findById(Long id) {
+		return cowalkPostJpaRepository.findById(id);
 	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkPostCoreRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkPostCoreRepository.java
@@ -1,0 +1,27 @@
+package com.dongsan.domain.domains.cowalk.infrastructure;
+
+import org.springframework.stereotype.Repository;
+
+import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
+import com.dongsan.domain.domains.cowalk.domain.CowalkPostRepository;
+import com.dongsan.domain.domains.cowalk.domain.QCowalkPost;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+@Repository
+public class CowalkPostCoreRepository implements CowalkPostRepository {
+
+	private final CowalkPostJpaRepository cowalkPostJpaRepository;
+	private final JPAQueryFactory queryFactory;
+
+	private final QCowalkPost qCowalkPost = QCowalkPost.cowalkPost;
+
+	public CowalkPostCoreRepository(CowalkPostJpaRepository cowalkPostJpaRepository, JPAQueryFactory queryFactory) {
+		this.cowalkPostJpaRepository = cowalkPostJpaRepository;
+		this.queryFactory = queryFactory;
+	}
+
+	@Override
+	public void save(CowalkPost cowalkPost) {
+		cowalkPostJpaRepository.save(cowalkPost);
+	}
+}

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkPostCoreRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkPostCoreRepository.java
@@ -15,41 +15,41 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 @Repository
 public class CowalkPostCoreRepository implements CowalkPostRepository {
 
-	private final CowalkPostJpaRepository cowalkPostJpaRepository;
-	private final JPAQueryFactory queryFactory;
+    private final CowalkPostJpaRepository cowalkPostJpaRepository;
+    private final JPAQueryFactory queryFactory;
 
-	private final QCowalkPost cowalkPost = QCowalkPost.cowalkPost;
+    private final QCowalkPost cowalkPost = QCowalkPost.cowalkPost;
 
-	public CowalkPostCoreRepository(CowalkPostJpaRepository cowalkPostJpaRepository, JPAQueryFactory queryFactory) {
-		this.cowalkPostJpaRepository = cowalkPostJpaRepository;
-		this.queryFactory = queryFactory;
-	}
+    public CowalkPostCoreRepository(CowalkPostJpaRepository cowalkPostJpaRepository, JPAQueryFactory queryFactory) {
+        this.cowalkPostJpaRepository = cowalkPostJpaRepository;
+        this.queryFactory = queryFactory;
+    }
 
-	@Override
-	public void save(CowalkPost cowalkPost) {
-		cowalkPostJpaRepository.save(cowalkPost);
-	}
+    @Override
+    public void save(CowalkPost cowalkPost) {
+        cowalkPostJpaRepository.save(cowalkPost);
+    }
 
-	@Override
-	public Optional<CowalkPost> findById(Long id) {
-		return cowalkPostJpaRepository.findById(id);
-	}
+    @Override
+    public Optional<CowalkPost> findById(Long id) {
+        return cowalkPostJpaRepository.findById(id);
+    }
 
-	@Override
-	public CursorPage<CowalkPost> getCowalkPosts(Integer size, Long lastId, Long crewId) {
-		List<CowalkPost> cowalkPosts = queryFactory.selectFrom(cowalkPost)
-			.where(
-				cowalkPost.crewId.eq(crewId),
-				cowalkPostIdLt(lastId)
-			)
-			.orderBy(cowalkPost.id.desc())
-			.limit(size + 1L)
-			.fetch();
+    @Override
+    public CursorPage<CowalkPost> getCowalkPosts(Integer size, Long lastId, Long crewId) {
+        List<CowalkPost> cowalkPosts = queryFactory.selectFrom(cowalkPost)
+                .where(
+                        cowalkPost.crewId.eq(crewId),
+                        cowalkPostIdLt(lastId)
+                )
+                .orderBy(cowalkPost.id.desc())
+                .limit(size + 1L)
+                .fetch();
 
-		return new CursorPage<>(cowalkPosts, size);
-	}
+        return new CursorPage<>(cowalkPosts, size);
+    }
 
-	private BooleanExpression cowalkPostIdLt(Long id) {
-		return id == null ? null : cowalkPost.id.lt(id);
-	}
+    private BooleanExpression cowalkPostIdLt(Long id) {
+        return id == null ? null : cowalkPost.id.lt(id);
+    }
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkPostJpaRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkPostJpaRepository.java
@@ -1,0 +1,10 @@
+package com.dongsan.domain.domains.cowalk.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
+
+@Repository
+public interface CowalkPostJpaRepository extends JpaRepository<CowalkPost, Long> {
+}

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkCommentRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkCommentRdbService.java
@@ -11,17 +11,17 @@ import com.dongsan.domain.domains.cowalk.domain.CowalkCommentRepository;
 @Service
 @Transactional
 public class CowalkCommentRdbService {
-	private final CowalkCommentRepository cowalkCommentRepository;
+    private final CowalkCommentRepository cowalkCommentRepository;
 
-	public CowalkCommentRdbService(CowalkCommentRepository cowalkCommentRepository) {
-		this.cowalkCommentRepository = cowalkCommentRepository;
-	}
+    public CowalkCommentRdbService(CowalkCommentRepository cowalkCommentRepository) {
+        this.cowalkCommentRepository = cowalkCommentRepository;
+    }
 
-	public Integer countByCowalkPostId(Long cowalkPostId) {
-		return cowalkCommentRepository.countByCowalkPostId(cowalkPostId);
-	}
+    public Integer countByCowalkPostId(Long cowalkPostId) {
+        return cowalkCommentRepository.countByCowalkPostId(cowalkPostId);
+    }
 
-	public Map<Long, Integer> countByCowalkPostIds(List<Long> cowalkPostIds) {
-		return cowalkCommentRepository.countByCowalkPostIds(cowalkPostIds);
-	}
+    public Map<Long, Integer> countByCowalkPostIds(List<Long> cowalkPostIds) {
+        return cowalkCommentRepository.countByCowalkPostIds(cowalkPostIds);
+    }
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkCommentRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkCommentRdbService.java
@@ -1,5 +1,8 @@
 package com.dongsan.domain.domains.cowalk.service;
 
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,5 +19,9 @@ public class CowalkCommentRdbService {
 
 	public Integer countByCowalkPostId(Long cowalkPostId) {
 		return cowalkCommentRepository.countByCowalkPostId(cowalkPostId);
+	}
+
+	public Map<Long, Integer> countByCowalkPostIds(List<Long> cowalkPostIds) {
+		return cowalkCommentRepository.countByCowalkPostIds(cowalkPostIds);
 	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkCommentRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkCommentRdbService.java
@@ -1,0 +1,20 @@
+package com.dongsan.domain.domains.cowalk.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dongsan.domain.domains.cowalk.domain.CowalkCommentRepository;
+
+@Service
+@Transactional
+public class CowalkCommentRdbService {
+	private final CowalkCommentRepository cowalkCommentRepository;
+
+	public CowalkCommentRdbService(CowalkCommentRepository cowalkCommentRepository) {
+		this.cowalkCommentRepository = cowalkCommentRepository;
+	}
+
+	public Integer countByCowalkPostId(Long cowalkPostId) {
+		return cowalkCommentRepository.countByCowalkPostId(cowalkPostId);
+	}
+}

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkParticipantRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkParticipantRdbService.java
@@ -2,6 +2,9 @@ package com.dongsan.domain.domains.cowalk.service;
 
 import static com.dongsan.domain.support.error.CoreErrorCode.*;
 
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,5 +39,9 @@ public class CowalkParticipantRdbService {
 		if (isJoin(memberId, cowalkPostId)) {
 			throw new CoreException(COWALK_PARTICIPANT_ALREADY_JOIN);
 		}
+	}
+
+	public Map<Long, Integer> countByCowalkPostIds(List<Long> cowalkPostIds) {
+		return cowalkParticipantRepository.countByCowalkPostIds(cowalkPostIds);
 	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkParticipantRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkParticipantRdbService.java
@@ -1,0 +1,23 @@
+package com.dongsan.domain.domains.cowalk.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dongsan.domain.domains.cowalk.domain.CowalkParticipant;
+import com.dongsan.domain.domains.cowalk.domain.CowalkParticipantRepository;
+
+@Service
+@Transactional
+public class CowalkParticipantRdbService {
+	private final CowalkParticipantRepository cowalkParticipantRepository;
+
+	public CowalkParticipantRdbService(CowalkParticipantRepository cowalkParticipantRepository) {
+		this.cowalkParticipantRepository = cowalkParticipantRepository;
+	}
+
+	public Long save(Long memberId, Long cowalkPostId) {
+		CowalkParticipant cowalkParticipant = new CowalkParticipant(cowalkPostId, memberId);
+		cowalkParticipantRepository.save(cowalkParticipant);
+		return cowalkParticipant.getId();
+	}
+}

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkParticipantRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkParticipantRdbService.java
@@ -1,10 +1,13 @@
 package com.dongsan.domain.domains.cowalk.service;
 
+import static com.dongsan.domain.support.error.CoreErrorCode.*;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dongsan.domain.domains.cowalk.domain.CowalkParticipant;
 import com.dongsan.domain.domains.cowalk.domain.CowalkParticipantRepository;
+import com.dongsan.domain.support.error.CoreException;
 
 @Service
 @Transactional
@@ -23,5 +26,15 @@ public class CowalkParticipantRdbService {
 
 	public Integer countByCowalkPostId(Long cowalkPostId) {
 		return cowalkParticipantRepository.countByCowalkPostId(cowalkPostId);
+	}
+
+	public Boolean isJoin(Long memberId, Long cowalkPostId) {
+		return cowalkParticipantRepository.existsByMemberIdAndCowalkPostId(memberId, cowalkPostId);
+	}
+
+	public void validAlreadyJoin(Long memberId, Long cowalkPostId) {
+		if (isJoin(memberId, cowalkPostId)) {
+			throw new CoreException(COWALK_PARTICIPANT_ALREADY_JOIN);
+		}
 	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkParticipantRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkParticipantRdbService.java
@@ -22,6 +22,7 @@ public class CowalkParticipantRdbService {
 	}
 
 	public Long save(Long memberId, Long cowalkPostId) {
+		validAlreadyJoin(memberId, cowalkPostId);
 		CowalkParticipant cowalkParticipant = new CowalkParticipant(cowalkPostId, memberId);
 		cowalkParticipantRepository.save(cowalkParticipant);
 		return cowalkParticipant.getId();

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkParticipantRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkParticipantRdbService.java
@@ -20,4 +20,8 @@ public class CowalkParticipantRdbService {
 		cowalkParticipantRepository.save(cowalkParticipant);
 		return cowalkParticipant.getId();
 	}
+
+	public Integer countByCowalkPostId(Long cowalkPostId) {
+		return cowalkParticipantRepository.countByCowalkPostId(cowalkPostId);
+	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkParticipantRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkParticipantRdbService.java
@@ -15,34 +15,34 @@ import com.dongsan.domain.support.error.CoreException;
 @Service
 @Transactional
 public class CowalkParticipantRdbService {
-	private final CowalkParticipantRepository cowalkParticipantRepository;
+    private final CowalkParticipantRepository cowalkParticipantRepository;
 
-	public CowalkParticipantRdbService(CowalkParticipantRepository cowalkParticipantRepository) {
-		this.cowalkParticipantRepository = cowalkParticipantRepository;
-	}
+    public CowalkParticipantRdbService(CowalkParticipantRepository cowalkParticipantRepository) {
+        this.cowalkParticipantRepository = cowalkParticipantRepository;
+    }
 
-	public Long save(Long memberId, Long cowalkPostId) {
-		validAlreadyJoin(memberId, cowalkPostId);
-		CowalkParticipant cowalkParticipant = new CowalkParticipant(cowalkPostId, memberId);
-		cowalkParticipantRepository.save(cowalkParticipant);
-		return cowalkParticipant.getId();
-	}
+    public Long save(Long memberId, Long cowalkPostId) {
+        validAlreadyJoin(memberId, cowalkPostId);
+        CowalkParticipant cowalkParticipant = new CowalkParticipant(cowalkPostId, memberId);
+        cowalkParticipantRepository.save(cowalkParticipant);
+        return cowalkParticipant.getId();
+    }
 
-	public Integer countByCowalkPostId(Long cowalkPostId) {
-		return cowalkParticipantRepository.countByCowalkPostId(cowalkPostId);
-	}
+    public Integer countByCowalkPostId(Long cowalkPostId) {
+        return cowalkParticipantRepository.countByCowalkPostId(cowalkPostId);
+    }
 
-	public Boolean isJoin(Long memberId, Long cowalkPostId) {
-		return cowalkParticipantRepository.existsByMemberIdAndCowalkPostId(memberId, cowalkPostId);
-	}
+    public Boolean isJoin(Long memberId, Long cowalkPostId) {
+        return cowalkParticipantRepository.existsByMemberIdAndCowalkPostId(memberId, cowalkPostId);
+    }
 
-	public void validAlreadyJoin(Long memberId, Long cowalkPostId) {
-		if (isJoin(memberId, cowalkPostId)) {
-			throw new CoreException(COWALK_PARTICIPANT_ALREADY_JOIN);
-		}
-	}
+    public void validAlreadyJoin(Long memberId, Long cowalkPostId) {
+        if (isJoin(memberId, cowalkPostId)) {
+            throw new CoreException(COWALK_PARTICIPANT_ALREADY_JOIN);
+        }
+    }
 
-	public Map<Long, Integer> countByCowalkPostIds(List<Long> cowalkPostIds) {
-		return cowalkParticipantRepository.countByCowalkPostIds(cowalkPostIds);
-	}
+    public Map<Long, Integer> countByCowalkPostIds(List<Long> cowalkPostIds) {
+        return cowalkParticipantRepository.countByCowalkPostIds(cowalkPostIds);
+    }
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkPostRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkPostRdbService.java
@@ -14,29 +14,29 @@ import com.dongsan.domain.support.util.CursorPage;
 @Service
 @Transactional
 public class CowalkPostRdbService {
-	private final CowalkPostRepository cowalkPostRepository;
+    private final CowalkPostRepository cowalkPostRepository;
 
-	public CowalkPostRdbService(CowalkPostRepository cowalkPostRepository) {
-		this.cowalkPostRepository = cowalkPostRepository;
-	}
+    public CowalkPostRdbService(CowalkPostRepository cowalkPostRepository) {
+        this.cowalkPostRepository = cowalkPostRepository;
+    }
 
-	public CowalkPost getCowalkPost(Long id) {
-		return cowalkPostRepository.findById(id)
-			.orElseThrow(() -> new CoreException(COWALK_NOT_FOUND));
-	}
+    public CowalkPost getCowalkPost(Long id) {
+        return cowalkPostRepository.findById(id)
+                .orElseThrow(() -> new CoreException(COWALK_NOT_FOUND));
+    }
 
-	public Long save(CreateCowalkPostCommand command) {
-		CowalkPost cowalkPost = new CowalkPost(command);
-		cowalkPostRepository.save(cowalkPost);
-		return cowalkPost.getId();
-	}
+    public Long save(CreateCowalkPostCommand command) {
+        CowalkPost cowalkPost = new CowalkPost(command);
+        cowalkPostRepository.save(cowalkPost);
+        return cowalkPost.getId();
+    }
 
-	public CursorPage<CowalkPost> getCowalkPosts(Integer size, Long lastId, Long crewId) {
-		return cowalkPostRepository.getCowalkPosts(size, lastId, crewId);
-	}
+    public CursorPage<CowalkPost> getCowalkPosts(Integer size, Long lastId, Long crewId) {
+        return cowalkPostRepository.getCowalkPosts(size, lastId, crewId);
+    }
 
-	public void validJoin(Long cowalkPostId, Integer participantCount) {
-		CowalkPost cowalkPost = getCowalkPost(cowalkPostId);
-		cowalkPost.validCapacity(participantCount);
-	}
+    public void validJoin(Long cowalkPostId, Integer participantCount) {
+        CowalkPost cowalkPost = getCowalkPost(cowalkPostId);
+        cowalkPost.validCapacity(participantCount);
+    }
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkPostRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkPostRdbService.java
@@ -1,11 +1,14 @@
 package com.dongsan.domain.domains.cowalk.service;
 
+import static com.dongsan.domain.support.error.CoreErrorCode.*;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
 import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
 import com.dongsan.domain.domains.cowalk.domain.CowalkPostRepository;
+import com.dongsan.domain.support.error.CoreException;
 
 @Service
 @Transactional
@@ -14,6 +17,11 @@ public class CowalkPostRdbService {
 
 	public CowalkPostRdbService(CowalkPostRepository cowalkPostRepository) {
 		this.cowalkPostRepository = cowalkPostRepository;
+	}
+
+	public CowalkPost getCowalkPost(Long id) {
+		return cowalkPostRepository.findById(id)
+			.orElseThrow(() -> new CoreException(COWALK_NOT_FOUND));
 	}
 
 	public Long save(CreateCowalkPostCommand command) {

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkPostRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkPostRdbService.java
@@ -9,6 +9,7 @@ import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
 import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
 import com.dongsan.domain.domains.cowalk.domain.CowalkPostRepository;
 import com.dongsan.domain.support.error.CoreException;
+import com.dongsan.domain.support.util.CursorPage;
 
 @Service
 @Transactional
@@ -28,5 +29,9 @@ public class CowalkPostRdbService {
 		CowalkPost cowalkPost = new CowalkPost(command);
 		cowalkPostRepository.save(cowalkPost);
 		return cowalkPost.getId();
+	}
+
+	public CursorPage<CowalkPost> getCowalkPosts(Integer size, Long lastId, Long crewId) {
+		return cowalkPostRepository.getCowalkPosts(size, lastId, crewId);
 	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkPostRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkPostRdbService.java
@@ -34,4 +34,9 @@ public class CowalkPostRdbService {
 	public CursorPage<CowalkPost> getCowalkPosts(Integer size, Long lastId, Long crewId) {
 		return cowalkPostRepository.getCowalkPosts(size, lastId, crewId);
 	}
+
+	public void validCapacity(Long cowalkPostId, Integer participantCount) {
+		CowalkPost cowalkPost = getCowalkPost(cowalkPostId);
+		cowalkPost.validCapacity(participantCount);
+	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkPostRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkPostRdbService.java
@@ -35,7 +35,7 @@ public class CowalkPostRdbService {
 		return cowalkPostRepository.getCowalkPosts(size, lastId, crewId);
 	}
 
-	public void validCapacity(Long cowalkPostId, Integer participantCount) {
+	public void validJoin(Long cowalkPostId, Integer participantCount) {
 		CowalkPost cowalkPost = getCowalkPost(cowalkPostId);
 		cowalkPost.validCapacity(participantCount);
 	}

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkPostRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkPostRdbService.java
@@ -1,0 +1,24 @@
+package com.dongsan.domain.domains.cowalk.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
+import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
+import com.dongsan.domain.domains.cowalk.domain.CowalkPostRepository;
+
+@Service
+@Transactional
+public class CowalkPostRdbService {
+	private final CowalkPostRepository cowalkPostRepository;
+
+	public CowalkPostRdbService(CowalkPostRepository cowalkPostRepository) {
+		this.cowalkPostRepository = cowalkPostRepository;
+	}
+
+	public Long save(CreateCowalkPostCommand command) {
+		CowalkPost cowalkPost = new CowalkPost(command);
+		cowalkPostRepository.save(cowalkPost);
+		return cowalkPost.getId();
+	}
+}

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/crew/service/CrewMemberRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/crew/service/CrewMemberRdbService.java
@@ -1,34 +1,42 @@
 package com.dongsan.domain.domains.crew.service;
 
+import org.springframework.stereotype.Service;
+
 import com.dongsan.domain.domains.crew.domain.CrewMember;
 import com.dongsan.domain.domains.crew.domain.CrewMemberRepository;
 import com.dongsan.domain.domains.crew.domain.CrewMemberRole;
 import com.dongsan.domain.support.error.CoreErrorCode;
 import com.dongsan.domain.support.error.CoreException;
-import org.springframework.stereotype.Service;
 
 @Service
 public class CrewMemberRdbService {
-    private final CrewMemberRepository crewMemberRepository;
+	private final CrewMemberRepository crewMemberRepository;
 
-    public CrewMemberRdbService(CrewMemberRepository crewMemberRepository) {
-        this.crewMemberRepository = crewMemberRepository;
-    }
+	public CrewMemberRdbService(CrewMemberRepository crewMemberRepository) {
+		this.crewMemberRepository = crewMemberRepository;
+	}
 
-    public void saveManager(Long crewId, Long memberId) {
-        CrewMember crewMember = new CrewMember(crewId, memberId, CrewMemberRole.MANAGER);
-        crewMemberRepository.save(crewMember);
-    }
+	public void saveManager(Long crewId, Long memberId) {
+		CrewMember crewMember = new CrewMember(crewId, memberId, CrewMemberRole.MANAGER);
+		crewMemberRepository.save(crewMember);
+	}
 
-    public void leaveCrew(Long crewId, Long memberId) {
-        boolean isCrewMember = isCrewMember(crewId, memberId);
-        if (!isCrewMember) {
-            throw new CoreException(CoreErrorCode.CREW_NOT_JOINED);
-        }
-        crewMemberRepository.deleteByCrewIdAndMemberId(crewId, memberId);
-    }
+	public void leaveCrew(Long crewId, Long memberId) {
+		boolean isCrewMember = isCrewMember(crewId, memberId);
+		if (!isCrewMember) {
+			throw new CoreException(CoreErrorCode.CREW_NOT_JOINED);
+		}
+		crewMemberRepository.deleteByCrewIdAndMemberId(crewId, memberId);
+	}
 
-    private boolean isCrewMember(Long crewId, Long memberId) {
-        return crewMemberRepository.existsByCrewIdAndMemberId(crewId, memberId);
-    }
+	private boolean isCrewMember(Long crewId, Long memberId) {
+		return crewMemberRepository.existsByCrewIdAndMemberId(crewId, memberId);
+	}
+
+	public void validateIsCrewMember(Long crewId, Long memberId) {
+		boolean isCrewMember = isCrewMember(crewId, memberId);
+		if (!isCrewMember) {
+			throw new CoreException(CoreErrorCode.CREW_NOT_JOINED);
+		}
+	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/member/MemberCoreRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/member/MemberCoreRepository.java
@@ -1,37 +1,44 @@
 package com.dongsan.domain.domains.member;
 
-import com.dongsan.domain.domains.auth.Provider;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import com.dongsan.domain.domains.auth.Provider;
 
 @Repository
 public class MemberCoreRepository implements MemberRepository {
-    private final MemberJpaRepository memberJpaRepository;
+	private final MemberJpaRepository memberJpaRepository;
 
-    public MemberCoreRepository(MemberJpaRepository memberJpaRepository) {
-        this.memberJpaRepository = memberJpaRepository;
-    }
+	public MemberCoreRepository(MemberJpaRepository memberJpaRepository) {
+		this.memberJpaRepository = memberJpaRepository;
+	}
 
-    @Override
-    public Optional<Member> findById(Long memberId) {
-        return memberJpaRepository.findById(memberId);
-    }
+	@Override
+	public Optional<Member> findById(Long memberId) {
+		return memberJpaRepository.findById(memberId);
+	}
 
-    @Override
-    public Optional<Member> findByEmail(String email) {
-        return memberJpaRepository.findByEmail(email);
-    }
+	@Override
+	public Optional<Member> findByEmail(String email) {
+		return memberJpaRepository.findByEmail(email);
+	}
 
-    @Override
-    public Member save(String email, String nickname, String profileImageUrl, MemberRole role, Provider provider) {
-        Member member = new Member(email, nickname, profileImageUrl, role, provider);
-        memberJpaRepository.save(member);
-        return member;
-    }
+	@Override
+	public Member save(String email, String nickname, String profileImageUrl, MemberRole role, Provider provider) {
+		Member member = new Member(email, nickname, profileImageUrl, role, provider);
+		memberJpaRepository.save(member);
+		return member;
+	}
 
-    @Override
-    public Optional<Member> findByEmailAndProvider(String email, Provider provider) {
-        return memberJpaRepository.findByEmailAndProvider(email, provider);
-    }
+	@Override
+	public Optional<Member> findByEmailAndProvider(String email, Provider provider) {
+		return memberJpaRepository.findByEmailAndProvider(email, provider);
+	}
+
+	@Override
+	public List<Member> findAllByIdIn(List<Long> ids) {
+		return memberJpaRepository.findAllByIdIn(ids);
+	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/member/MemberJpaRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/member/MemberJpaRepository.java
@@ -1,14 +1,18 @@
 package com.dongsan.domain.domains.member;
 
-import com.dongsan.domain.domains.auth.Provider;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import com.dongsan.domain.domains.auth.Provider;
 
 @Repository
 public interface MemberJpaRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(String email);
+	Optional<Member> findByEmail(String email);
 
-    Optional<Member> findByEmailAndProvider(String email, Provider provider);
+	Optional<Member> findByEmailAndProvider(String email, Provider provider);
+
+	List<Member> findAllByIdIn(List<Long> ids);
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/member/MemberRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/member/MemberRepository.java
@@ -1,18 +1,21 @@
 package com.dongsan.domain.domains.member;
 
-import com.dongsan.domain.domains.auth.Provider;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import com.dongsan.domain.domains.auth.Provider;
 
 @Repository
 public interface MemberRepository {
-    Optional<Member> findById(Long memberId);
+	Optional<Member> findById(Long memberId);
 
-    Optional<Member> findByEmail(String email);
+	Optional<Member> findByEmail(String email);
 
-    Member save(String email, String nickname, String profileImageUrl, MemberRole role, Provider provider);
+	Member save(String email, String nickname, String profileImageUrl, MemberRole role, Provider provider);
 
-    Optional<Member> findByEmailAndProvider(String email, Provider provider);
+	Optional<Member> findByEmailAndProvider(String email, Provider provider);
 
+	List<Member> findAllByIdIn(List<Long> ids);
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/member/MemberService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/member/MemberService.java
@@ -1,44 +1,55 @@
 package com.dongsan.domain.domains.member;
 
-import com.dongsan.domain.domains.auth.Provider;
-import com.dongsan.domain.support.error.CoreErrorCode;
-import com.dongsan.domain.support.error.CoreException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
+import com.dongsan.domain.domains.auth.Provider;
+import com.dongsan.domain.support.error.CoreErrorCode;
+import com.dongsan.domain.support.error.CoreException;
 
 @Service
 public class MemberService {
-    private final MemberRepository memberRepository;
+	private final MemberRepository memberRepository;
 
-    public MemberService(MemberRepository memberRepository) {
-        this.memberRepository = memberRepository;
-    }
+	public MemberService(MemberRepository memberRepository) {
+		this.memberRepository = memberRepository;
+	}
 
-    public Member getMember(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(
-                        () -> new CoreException(CoreErrorCode.MEMBER_NOT_FOUND)
-                );
-    }
+	public Member getMember(Long memberId) {
+		return memberRepository.findById(memberId)
+			.orElseThrow(
+				() -> new CoreException(CoreErrorCode.MEMBER_NOT_FOUND)
+			);
+	}
 
-    public Optional<Member> getOptionalMember(Long memberId) {
-        return memberRepository.findById(memberId);
-    }
+	public Optional<Member> getOptionalMember(Long memberId) {
+		return memberRepository.findById(memberId);
+	}
 
-    public Optional<Member> getOptionalMemberByEmailAndProvider(String email, Provider provider) {
-        return memberRepository.findByEmailAndProvider(email, provider);
-    }
+	public Optional<Member> getOptionalMemberByEmailAndProvider(String email, Provider provider) {
+		return memberRepository.findByEmailAndProvider(email, provider);
+	}
 
-    @Transactional
-    public Member save(String email, String nickname, String profileImageUrl, MemberRole role, Provider provider) {
-        return memberRepository.save(email, nickname, profileImageUrl, role, provider);
-    }
+	@Transactional
+	public Member save(String email, String nickname, String profileImageUrl, MemberRole role, Provider provider) {
+		return memberRepository.save(email, nickname, profileImageUrl, role, provider);
+	}
 
-    @Transactional
-    public void patchNickname(Long memberId, String nickname) {
-        Member member = getMember(memberId);
-        member.changeNickname(nickname);
-    }
+	@Transactional
+	public void patchNickname(Long memberId, String nickname) {
+		Member member = getMember(memberId);
+		member.changeNickname(nickname);
+	}
+
+	public Map<Long, Member> getMemberMap(List<Long> memberIds) {
+		List<Member> memberList = memberRepository.findAllByIdIn(memberIds);
+		return memberList.stream()
+			.collect(Collectors.toMap(Member::getId, Function.identity()));
+	}
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/support/error/CoreErrorCode.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/support/error/CoreErrorCode.java
@@ -58,8 +58,7 @@ public enum CoreErrorCode {
 	// cowalk
 	COWALK_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "COWALK-01", "존재하지 않는 같이 산책 입니다."),
 	COWALK_PARTICIPANT_ALREADY_JOIN(CoreErrorStatus.BAD_REQUEST, "COWALK-02", "이미 같이 산책에 참여했습니다."),
-
-	;
+	COWALK_PARTICIPANT_LIMIT(CoreErrorStatus.BAD_REQUEST, "COWALK-03", "같이 산책 인원이 이미 모두 찼습니다.");
 
 	private final CoreErrorStatus httpStatus;
 	private final String code;

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/support/error/CoreErrorCode.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/support/error/CoreErrorCode.java
@@ -1,85 +1,85 @@
 package com.dongsan.domain.support.error;
 
 public enum CoreErrorCode {
-    // bookmark
-    BOOKMARK_NOT_EXIST(CoreErrorStatus.NOT_FOUND, "BOOKMARK-01", "해당 북마크가 존재하지 않습니다."),
-    SAME_BOOKMARK_NAME_EXIST(CoreErrorStatus.CONFLICT, "BOOKMARK-02", "이름이 같은 북마크가 이미 존재합니다."),
-    NOT_BOOKMARK_OWNER(CoreErrorStatus.FORBIDDEN, "BOOKMARK-03", "해당 북마크의 생성자가 아닙니다."),
-    WALKWAY_ALREADY_EXIST_IN_BOOKMARK(CoreErrorStatus.CONFLICT, "BOOKMARK-04", "북마크에 이미 존재하는 산책로입니다."),
-    WALKWAY_NOT_EXIST_IN_BOOKMARK(CoreErrorStatus.NOT_FOUND, "BOOKMARK-05", "북마크에 존재하지 않는 산책로입니다."),
+	// bookmark
+	BOOKMARK_NOT_EXIST(CoreErrorStatus.NOT_FOUND, "BOOKMARK-01", "해당 북마크가 존재하지 않습니다."),
+	SAME_BOOKMARK_NAME_EXIST(CoreErrorStatus.CONFLICT, "BOOKMARK-02", "이름이 같은 북마크가 이미 존재합니다."),
+	NOT_BOOKMARK_OWNER(CoreErrorStatus.FORBIDDEN, "BOOKMARK-03", "해당 북마크의 생성자가 아닙니다."),
+	WALKWAY_ALREADY_EXIST_IN_BOOKMARK(CoreErrorStatus.CONFLICT, "BOOKMARK-04", "북마크에 이미 존재하는 산책로입니다."),
+	WALKWAY_NOT_EXIST_IN_BOOKMARK(CoreErrorStatus.NOT_FOUND, "BOOKMARK-05", "북마크에 존재하지 않는 산책로입니다."),
 
-    // image
-    IMAGE_NOT_EXISTS(CoreErrorStatus.NOT_FOUND, "IMAGE-01", "존재하지 않은 이미지입니다."),
+	// image
+	IMAGE_NOT_EXISTS(CoreErrorStatus.NOT_FOUND, "IMAGE-01", "존재하지 않은 이미지입니다."),
 
-    // walkway
-    INVALID_SEARCH_TYPE(CoreErrorStatus.BAD_REQUEST, "WALKWAY-01", "유효하지 산책로 검색 타입 입니다."),
-    WALKWAY_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "WALKWAY-02", "존재하지 않는 산책로 입니다."),
-    NOT_WALKWAY_OWNER(CoreErrorStatus.FORBIDDEN, "WALKWAY-03", "권한이 없는 산책로 입니다."),
-    WALKWAY_CANT_ACCESS(CoreErrorStatus.FORBIDDEN, "WALKWAY-04", "접근할 수 없는 산책로 입니다. (타인이 등록한 비공개 산책로)"),
-    ALREADY_LIKED_WALKWAY(CoreErrorStatus.BAD_REQUEST, "WALKWAY-05", "이미 좋아요를 한 산책로입니다."),
-    NOT_LIKED_WALKWAY(CoreErrorStatus.BAD_REQUEST, "WALKWAY-06", "좋아요를 누른적 없는 산책로입니다."),
-    NOT_ENOUGH_DISTANCE(CoreErrorStatus.FORBIDDEN, "WALKWAY-07", "충분히 산책하지 않았습니다."),
-    ALREADY_REVIEWED(CoreErrorStatus.CONFLICT, "WALKWAY-08", "이미 리뷰를 작성하였습니다."),
-    WALKWAY_NAME_NOT_BLANK(CoreErrorStatus.BAD_REQUEST, "WALKWAY-10", "산책로 이름은 공백일 수 없습니다."),
-    WALKWAY_DISTANCE_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-11", "산책로 등록 가능 거리는 0.2km 이상입니다."),
-    WALKWAY_TIME_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-12", "산책로 등록 가능 시간은 10분(600초) 이상 입니다."),
+	// walkway
+	INVALID_SEARCH_TYPE(CoreErrorStatus.BAD_REQUEST, "WALKWAY-01", "유효하지 산책로 검색 타입 입니다."),
+	WALKWAY_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "WALKWAY-02", "존재하지 않는 산책로 입니다."),
+	NOT_WALKWAY_OWNER(CoreErrorStatus.FORBIDDEN, "WALKWAY-03", "권한이 없는 산책로 입니다."),
+	WALKWAY_CANT_ACCESS(CoreErrorStatus.FORBIDDEN, "WALKWAY-04", "접근할 수 없는 산책로 입니다. (타인이 등록한 비공개 산책로)"),
+	ALREADY_LIKED_WALKWAY(CoreErrorStatus.BAD_REQUEST, "WALKWAY-05", "이미 좋아요를 한 산책로입니다."),
+	NOT_LIKED_WALKWAY(CoreErrorStatus.BAD_REQUEST, "WALKWAY-06", "좋아요를 누른적 없는 산책로입니다."),
+	NOT_ENOUGH_DISTANCE(CoreErrorStatus.FORBIDDEN, "WALKWAY-07", "충분히 산책하지 않았습니다."),
+	ALREADY_REVIEWED(CoreErrorStatus.CONFLICT, "WALKWAY-08", "이미 리뷰를 작성하였습니다."),
+	WALKWAY_NAME_NOT_BLANK(CoreErrorStatus.BAD_REQUEST, "WALKWAY-10", "산책로 이름은 공백일 수 없습니다."),
+	WALKWAY_DISTANCE_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-11", "산책로 등록 가능 거리는 0.2km 이상입니다."),
+	WALKWAY_TIME_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-12", "산책로 등록 가능 시간은 10분(600초) 이상 입니다."),
 
-    // member
-    MEMBER_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "MEMBER-01", "해당 회원이 존재하지 않습니다."),
+	// member
+	MEMBER_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "MEMBER-01", "해당 회원이 존재하지 않습니다."),
 
-    // review
-    REVIEW_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "REVIEW-01", "해당 리뷰는 존재하지 않습니다."),
-    INVALID_SORT_TYPE(CoreErrorStatus.BAD_REQUEST, "REVIEW-02", "유효하지 않은 정렬 타입 입니다."),
-    INVALID_RATING_VALUE(CoreErrorStatus.BAD_REQUEST, "REVIEW-03", "별점은 1 이상 5 이하의 정수입니다."),
-    REVIEW_CONTENT_BLANK(CoreErrorStatus.BAD_REQUEST, "REVIEW-04", "리뷰 내용을 필수로 작성해야합니다."),
-    REVIEW_CONTENT_GT_200(CoreErrorStatus.BAD_REQUEST, "REVIEW-05", "리뷰 내용은 200자를 넘길 수 없습니다."),
+	// review
+	REVIEW_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "REVIEW-01", "해당 리뷰는 존재하지 않습니다."),
+	INVALID_SORT_TYPE(CoreErrorStatus.BAD_REQUEST, "REVIEW-02", "유효하지 않은 정렬 타입 입니다."),
+	INVALID_RATING_VALUE(CoreErrorStatus.BAD_REQUEST, "REVIEW-03", "별점은 1 이상 5 이하의 정수입니다."),
+	REVIEW_CONTENT_BLANK(CoreErrorStatus.BAD_REQUEST, "REVIEW-04", "리뷰 내용을 필수로 작성해야합니다."),
+	REVIEW_CONTENT_GT_200(CoreErrorStatus.BAD_REQUEST, "REVIEW-05", "리뷰 내용은 200자를 넘길 수 없습니다."),
 
-    // walkway log
-    WALKWAY_LOG_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "WALKWAY-LOG-01", "존재하지 않는 산책로 이용 기록입니다."),
-    INVALID_OWNER_AND_WALKWAY(CoreErrorStatus.FORBIDDEN, "WALKWAY-LOG-02", "기록의 산책로와 유저가 다릅니다."),
-    WALKWAY_HISTORY_TIME_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-LOG-03", "산책 기록 등록 가능 거리는 0초 이상 입니다."),
-    WALKWAY_HISTORY_DISTANCE_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-LOG-04", "산책 기록 등록 가능 시간은 0km 이상 입니다."),
+	// walkway log
+	WALKWAY_LOG_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "WALKWAY-LOG-01", "존재하지 않는 산책로 이용 기록입니다."),
+	INVALID_OWNER_AND_WALKWAY(CoreErrorStatus.FORBIDDEN, "WALKWAY-LOG-02", "기록의 산책로와 유저가 다릅니다."),
+	WALKWAY_HISTORY_TIME_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-LOG-03", "산책 기록 등록 가능 거리는 0초 이상 입니다."),
+	WALKWAY_HISTORY_DISTANCE_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-LOG-04", "산책 기록 등록 가능 시간은 0km 이상 입니다."),
 
-    // auth provider
-    PROVIDER_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "PROVIDER-01", "존재하지 않는 Provider 입니다."),
+	// auth provider
+	PROVIDER_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "PROVIDER-01", "존재하지 않는 Provider 입니다."),
 
-    // crew
-    CREW_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "CREW-01", "존재하지 않는 크루 입니다."),
-    CREW_MEMBER_LIMIT_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-02", "크루 제한 가능 인원은 2명 이상 100명 이하입니다."),
-    CREW_NAME_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-03", "크루 이름은 1자 이상 20자 이하 입니다."),
-    CREW_DESCRIPTION_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-04", "크루 설명은 250자 이하 입니다."),
-    CREW_RULE_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-05", "크루 규칙은 250자 이하 입니다."),
-    PRIVATE_CREW_PASSWORD_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-06", "비공개 크루는 비밀번호를 필수로 입력해야하고, 8자 이상 20자 이하입니다."),
-    CREW_NAME_DUPLICATED(CoreErrorStatus.BAD_REQUEST, "CREW-07", "동일한 크루 이름이 이미 존재합니다."),
-    CREW_NOT_JOINED(CoreErrorStatus.FORBIDDEN, "CREW-08", "해당 크루에 가입되어 있지 않습니다."),
-    CREW_ALREADY_JOINED(CoreErrorStatus.CONFLICT, "CREW-09", "이미 해당 크루에 가입되어 있습니다."),
+	// crew
+	CREW_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "CREW-01", "존재하지 않는 크루 입니다."),
+	CREW_MEMBER_LIMIT_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-02", "크루 제한 가능 인원은 2명 이상 100명 이하입니다."),
+	CREW_NAME_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-03", "크루 이름은 1자 이상 20자 이하 입니다."),
+	CREW_DESCRIPTION_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-04", "크루 설명은 250자 이하 입니다."),
+	CREW_RULE_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-05", "크루 규칙은 250자 이하 입니다."),
+	PRIVATE_CREW_PASSWORD_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-06",
+		"비공개 크루는 비밀번호를 필수로 입력해야하고, 8자 이상 20자 이하입니다."),
+	CREW_NAME_DUPLICATED(CoreErrorStatus.BAD_REQUEST, "CREW-07", "동일한 크루 이름이 이미 존재합니다."),
+	CREW_NOT_JOINED(CoreErrorStatus.FORBIDDEN, "CREW-08", "해당 크루에 가입되어 있지 않습니다."),
+	CREW_ALREADY_JOINED(CoreErrorStatus.CONFLICT, "CREW-09", "이미 해당 크루에 가입되어 있습니다."),
 
+	// cowalk
+	COWALK_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "COWALK-01", "존재하지 않는 같이 산책 입니다."),
 
-    // cowalk
+	;
 
+	private final CoreErrorStatus httpStatus;
+	private final String code;
+	private final String message;
 
-    ;
+	CoreErrorCode(CoreErrorStatus httpStatus, String code, String message) {
+		this.httpStatus = httpStatus;
+		this.code = code;
+		this.message = message;
+	}
 
-    private final CoreErrorStatus httpStatus;
-    private final String code;
-    private final String message;
+	public CoreErrorStatus getHttpStatus() {
+		return httpStatus;
+	}
 
-    CoreErrorCode(CoreErrorStatus httpStatus, String code, String message) {
-        this.httpStatus = httpStatus;
-        this.code = code;
-        this.message = message;
-    }
+	public String getCode() {
+		return code;
+	}
 
-    public CoreErrorStatus getHttpStatus() {
-        return httpStatus;
-    }
-
-    public String getCode() {
-        return code;
-    }
-
-    public String getMessage() {
-        return message;
-    }
+	public String getMessage() {
+		return message;
+	}
 
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/support/error/CoreErrorCode.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/support/error/CoreErrorCode.java
@@ -1,85 +1,88 @@
 package com.dongsan.domain.support.error;
 
 public enum CoreErrorCode {
-	// bookmark
-	BOOKMARK_NOT_EXIST(CoreErrorStatus.NOT_FOUND, "BOOKMARK-01", "해당 북마크가 존재하지 않습니다."),
-	SAME_BOOKMARK_NAME_EXIST(CoreErrorStatus.CONFLICT, "BOOKMARK-02", "이름이 같은 북마크가 이미 존재합니다."),
-	NOT_BOOKMARK_OWNER(CoreErrorStatus.FORBIDDEN, "BOOKMARK-03", "해당 북마크의 생성자가 아닙니다."),
-	WALKWAY_ALREADY_EXIST_IN_BOOKMARK(CoreErrorStatus.CONFLICT, "BOOKMARK-04", "북마크에 이미 존재하는 산책로입니다."),
-	WALKWAY_NOT_EXIST_IN_BOOKMARK(CoreErrorStatus.NOT_FOUND, "BOOKMARK-05", "북마크에 존재하지 않는 산책로입니다."),
+    // bookmark
+    BOOKMARK_NOT_EXIST(CoreErrorStatus.NOT_FOUND, "BOOKMARK-01", "해당 북마크가 존재하지 않습니다."),
+    SAME_BOOKMARK_NAME_EXIST(CoreErrorStatus.CONFLICT, "BOOKMARK-02", "이름이 같은 북마크가 이미 존재합니다."),
+    NOT_BOOKMARK_OWNER(CoreErrorStatus.FORBIDDEN, "BOOKMARK-03", "해당 북마크의 생성자가 아닙니다."),
+    WALKWAY_ALREADY_EXIST_IN_BOOKMARK(CoreErrorStatus.CONFLICT, "BOOKMARK-04", "북마크에 이미 존재하는 산책로입니다."),
+    WALKWAY_NOT_EXIST_IN_BOOKMARK(CoreErrorStatus.NOT_FOUND, "BOOKMARK-05", "북마크에 존재하지 않는 산책로입니다."),
 
-	// image
-	IMAGE_NOT_EXISTS(CoreErrorStatus.NOT_FOUND, "IMAGE-01", "존재하지 않은 이미지입니다."),
+    // image
+    IMAGE_NOT_EXISTS(CoreErrorStatus.NOT_FOUND, "IMAGE-01", "존재하지 않은 이미지입니다."),
 
-	// walkway
-	INVALID_SEARCH_TYPE(CoreErrorStatus.BAD_REQUEST, "WALKWAY-01", "유효하지 산책로 검색 타입 입니다."),
-	WALKWAY_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "WALKWAY-02", "존재하지 않는 산책로 입니다."),
-	NOT_WALKWAY_OWNER(CoreErrorStatus.FORBIDDEN, "WALKWAY-03", "권한이 없는 산책로 입니다."),
-	WALKWAY_CANT_ACCESS(CoreErrorStatus.FORBIDDEN, "WALKWAY-04", "접근할 수 없는 산책로 입니다. (타인이 등록한 비공개 산책로)"),
-	ALREADY_LIKED_WALKWAY(CoreErrorStatus.BAD_REQUEST, "WALKWAY-05", "이미 좋아요를 한 산책로입니다."),
-	NOT_LIKED_WALKWAY(CoreErrorStatus.BAD_REQUEST, "WALKWAY-06", "좋아요를 누른적 없는 산책로입니다."),
-	NOT_ENOUGH_DISTANCE(CoreErrorStatus.FORBIDDEN, "WALKWAY-07", "충분히 산책하지 않았습니다."),
-	ALREADY_REVIEWED(CoreErrorStatus.CONFLICT, "WALKWAY-08", "이미 리뷰를 작성하였습니다."),
-	WALKWAY_NAME_NOT_BLANK(CoreErrorStatus.BAD_REQUEST, "WALKWAY-10", "산책로 이름은 공백일 수 없습니다."),
-	WALKWAY_DISTANCE_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-11", "산책로 등록 가능 거리는 0.2km 이상입니다."),
-	WALKWAY_TIME_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-12", "산책로 등록 가능 시간은 10분(600초) 이상 입니다."),
+    // walkway
+    INVALID_SEARCH_TYPE(CoreErrorStatus.BAD_REQUEST, "WALKWAY-01", "유효하지 산책로 검색 타입 입니다."),
+    WALKWAY_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "WALKWAY-02", "존재하지 않는 산책로 입니다."),
+    NOT_WALKWAY_OWNER(CoreErrorStatus.FORBIDDEN, "WALKWAY-03", "권한이 없는 산책로 입니다."),
+    WALKWAY_CANT_ACCESS(CoreErrorStatus.FORBIDDEN, "WALKWAY-04", "접근할 수 없는 산책로 입니다. (타인이 등록한 비공개 산책로)"),
+    ALREADY_LIKED_WALKWAY(CoreErrorStatus.BAD_REQUEST, "WALKWAY-05", "이미 좋아요를 한 산책로입니다."),
+    NOT_LIKED_WALKWAY(CoreErrorStatus.BAD_REQUEST, "WALKWAY-06", "좋아요를 누른적 없는 산책로입니다."),
+    NOT_ENOUGH_DISTANCE(CoreErrorStatus.FORBIDDEN, "WALKWAY-07", "충분히 산책하지 않았습니다."),
+    ALREADY_REVIEWED(CoreErrorStatus.CONFLICT, "WALKWAY-08", "이미 리뷰를 작성하였습니다."),
+    WALKWAY_NAME_NOT_BLANK(CoreErrorStatus.BAD_REQUEST, "WALKWAY-10", "산책로 이름은 공백일 수 없습니다."),
+    WALKWAY_DISTANCE_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-11", "산책로 등록 가능 거리는 0.2km 이상입니다."),
+    WALKWAY_TIME_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-12", "산책로 등록 가능 시간은 10분(600초) 이상 입니다."),
 
-	// member
-	MEMBER_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "MEMBER-01", "해당 회원이 존재하지 않습니다."),
+    // member
+    MEMBER_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "MEMBER-01", "해당 회원이 존재하지 않습니다."),
 
-	// review
-	REVIEW_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "REVIEW-01", "해당 리뷰는 존재하지 않습니다."),
-	INVALID_SORT_TYPE(CoreErrorStatus.BAD_REQUEST, "REVIEW-02", "유효하지 않은 정렬 타입 입니다."),
-	INVALID_RATING_VALUE(CoreErrorStatus.BAD_REQUEST, "REVIEW-03", "별점은 1 이상 5 이하의 정수입니다."),
-	REVIEW_CONTENT_BLANK(CoreErrorStatus.BAD_REQUEST, "REVIEW-04", "리뷰 내용을 필수로 작성해야합니다."),
-	REVIEW_CONTENT_GT_200(CoreErrorStatus.BAD_REQUEST, "REVIEW-05", "리뷰 내용은 200자를 넘길 수 없습니다."),
+    // review
+    REVIEW_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "REVIEW-01", "해당 리뷰는 존재하지 않습니다."),
+    INVALID_SORT_TYPE(CoreErrorStatus.BAD_REQUEST, "REVIEW-02", "유효하지 않은 정렬 타입 입니다."),
+    INVALID_RATING_VALUE(CoreErrorStatus.BAD_REQUEST, "REVIEW-03", "별점은 1 이상 5 이하의 정수입니다."),
+    REVIEW_CONTENT_BLANK(CoreErrorStatus.BAD_REQUEST, "REVIEW-04", "리뷰 내용을 필수로 작성해야합니다."),
+    REVIEW_CONTENT_GT_200(CoreErrorStatus.BAD_REQUEST, "REVIEW-05", "리뷰 내용은 200자를 넘길 수 없습니다."),
 
-	// walkway log
-	WALKWAY_LOG_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "WALKWAY-LOG-01", "존재하지 않는 산책로 이용 기록입니다."),
-	INVALID_OWNER_AND_WALKWAY(CoreErrorStatus.FORBIDDEN, "WALKWAY-LOG-02", "기록의 산책로와 유저가 다릅니다."),
-	WALKWAY_HISTORY_TIME_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-LOG-03", "산책 기록 등록 가능 거리는 0초 이상 입니다."),
-	WALKWAY_HISTORY_DISTANCE_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-LOG-04", "산책 기록 등록 가능 시간은 0km 이상 입니다."),
+    // walkway log
+    WALKWAY_LOG_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "WALKWAY-LOG-01", "존재하지 않는 산책로 이용 기록입니다."),
+    INVALID_OWNER_AND_WALKWAY(CoreErrorStatus.FORBIDDEN, "WALKWAY-LOG-02", "기록의 산책로와 유저가 다릅니다."),
+    WALKWAY_HISTORY_TIME_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-LOG-03", "산책 기록 등록 가능 거리는 0초 이상 입니다."),
+    WALKWAY_HISTORY_DISTANCE_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-LOG-04", "산책 기록 등록 가능 시간은 0km 이상 입니다."),
 
-	// auth provider
-	PROVIDER_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "PROVIDER-01", "존재하지 않는 Provider 입니다."),
+    // auth provider
+    PROVIDER_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "PROVIDER-01", "존재하지 않는 Provider 입니다."),
 
-	// crew
-	CREW_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "CREW-01", "존재하지 않는 크루 입니다."),
-	CREW_MEMBER_LIMIT_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-02", "크루 제한 가능 인원은 2명 이상 100명 이하입니다."),
-	CREW_NAME_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-03", "크루 이름은 1자 이상 20자 이하 입니다."),
-	CREW_DESCRIPTION_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-04", "크루 설명은 250자 이하 입니다."),
-	CREW_RULE_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-05", "크루 규칙은 250자 이하 입니다."),
-	PRIVATE_CREW_PASSWORD_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-06",
-		"비공개 크루는 비밀번호를 필수로 입력해야하고, 8자 이상 20자 이하입니다."),
-	CREW_NAME_DUPLICATED(CoreErrorStatus.BAD_REQUEST, "CREW-07", "동일한 크루 이름이 이미 존재합니다."),
-	CREW_NOT_JOINED(CoreErrorStatus.FORBIDDEN, "CREW-08", "해당 크루에 가입되어 있지 않습니다."),
-	CREW_ALREADY_JOINED(CoreErrorStatus.CONFLICT, "CREW-09", "이미 해당 크루에 가입되어 있습니다."),
+    // crew
+    CREW_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "CREW-01", "존재하지 않는 크루 입니다."),
+    CREW_MEMBER_LIMIT_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-02", "크루 제한 가능 인원은 2명 이상 100명 이하입니다."),
+    CREW_NAME_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-03", "크루 이름은 1자 이상 20자 이하 입니다."),
+    CREW_DESCRIPTION_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-04", "크루 설명은 250자 이하 입니다."),
+    CREW_RULE_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-05", "크루 규칙은 250자 이하 입니다."),
+    PRIVATE_CREW_PASSWORD_NOT_VALID(CoreErrorStatus.BAD_REQUEST, "CREW-06",
+            "비공개 크루는 비밀번호를 필수로 입력해야하고, 8자 이상 20자 이하입니다."),
+    CREW_NAME_DUPLICATED(CoreErrorStatus.BAD_REQUEST, "CREW-07", "동일한 크루 이름이 이미 존재합니다."),
+    CREW_NOT_JOINED(CoreErrorStatus.FORBIDDEN, "CREW-08", "해당 크루에 가입되어 있지 않습니다."),
+    CREW_ALREADY_JOINED(CoreErrorStatus.CONFLICT, "CREW-09", "이미 해당 크루에 가입되어 있습니다."),
 
-	// cowalk
-	COWALK_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "COWALK-01", "존재하지 않는 같이 산책 입니다."),
-	COWALK_PARTICIPANT_ALREADY_JOIN(CoreErrorStatus.BAD_REQUEST, "COWALK-02", "이미 같이 산책에 참여했습니다."),
-	COWALK_PARTICIPANT_LIMIT(CoreErrorStatus.BAD_REQUEST, "COWALK-03", "같이 산책 인원이 이미 모두 찼습니다.");
+    // cowalk
+    COWALK_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "COWALK-01", "존재하지 않는 같이 산책 입니다."),
+    COWALK_PARTICIPANT_ALREADY_JOIN(CoreErrorStatus.BAD_REQUEST, "COWALK-02", "이미 같이 산책에 참여했습니다."),
+    COWALK_PARTICIPANT_LIMIT(CoreErrorStatus.BAD_REQUEST, "COWALK-03", "같이 산책 인원이 이미 모두 찼습니다."),
+    COWALK_LOCK_FAIL(CoreErrorStatus.CONFLICT, "COWALK-04", "같이 산책 참여에 실패했습니다."),
 
-	private final CoreErrorStatus httpStatus;
-	private final String code;
-	private final String message;
+    ;
 
-	CoreErrorCode(CoreErrorStatus httpStatus, String code, String message) {
-		this.httpStatus = httpStatus;
-		this.code = code;
-		this.message = message;
-	}
+    private final CoreErrorStatus httpStatus;
+    private final String code;
+    private final String message;
 
-	public CoreErrorStatus getHttpStatus() {
-		return httpStatus;
-	}
+    CoreErrorCode(CoreErrorStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
 
-	public String getCode() {
-		return code;
-	}
+    public CoreErrorStatus getHttpStatus() {
+        return httpStatus;
+    }
 
-	public String getMessage() {
-		return message;
-	}
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
 
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/support/error/CoreErrorCode.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/support/error/CoreErrorCode.java
@@ -57,6 +57,7 @@ public enum CoreErrorCode {
 
 	// cowalk
 	COWALK_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "COWALK-01", "존재하지 않는 같이 산책 입니다."),
+	COWALK_PARTICIPANT_ALREADY_JOIN(CoreErrorStatus.BAD_REQUEST, "COWALK-02", "이미 같이 산책에 참여했습니다."),
 
 	;
 

--- a/dongsan-core/domain-rdb/src/test/java/com/dongsan/domain/domains/cowalk/domain/CowalkPostTest.java
+++ b/dongsan-core/domain-rdb/src/test/java/com/dongsan/domain/domains/cowalk/domain/CowalkPostTest.java
@@ -1,0 +1,35 @@
+package com.dongsan.domain.domains.cowalk.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
+import com.dongsan.domain.support.error.CoreException;
+
+class CowalkPostTest {
+
+	@Test
+	@DisplayName("participantCount(참가인원)이 capacity 이상이면 예외가 발생한다")
+	void Throw_Exception_Capacity_Limit() {
+		// given
+		Integer participantCount = 5;
+		Integer capacity = 5;
+		Long crewId = 1L;
+		Long memberId = 1L;
+
+		CreateCowalkPostCommand command
+			= new CreateCowalkPostCommand(crewId, memberId, LocalDate.now(), LocalTime.now(), capacity);
+
+		CowalkPost cowalkPost = new CowalkPost(command);
+
+		// when & then
+		assertThatThrownBy(() -> cowalkPost.validCapacity(participantCount))
+			.isInstanceOf(CoreException.class);
+	}
+
+}

--- a/dongsan-core/domain-redis/build.gradle
+++ b/dongsan-core/domain-redis/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.48.0'
 }
 
 // application.yml 설정 파일 복사

--- a/dongsan-core/domain-redis/src/main/java/com/dongsan/domain/domains/cowalk/CowalkPostLockService.java
+++ b/dongsan-core/domain-redis/src/main/java/com/dongsan/domain/domains/cowalk/CowalkPostLockService.java
@@ -19,30 +19,24 @@ public class CowalkPostLockService {
         return lockRepository.getFairLock(key);
     }
 
-    public RLock tryFairLock(Long cowalkPostId) throws InterruptedException {
+    public void unlock(RLock lock) {
+        lock.unlock();
+    }
+
+    public <T> T executeWithFairLock(Long cowalkPostId, Supplier<T> task) throws InterruptedException {
         long waitTime = 10;
         long leaseTime = 2;
 
         RLock lock = getFairLock(cowalkPostId);
 
         if (lock.tryLock(waitTime, leaseTime, TimeUnit.SECONDS)) {
-            return lock;
+            try {
+                return task.get();
+            } finally {
+                unlock(lock);
+            }
         } else {
             throw new InterruptedException("CowalkPostLockService : 락 획득 실패: " + cowalkPostId);
-        }
-    }
-
-    public void unlock(RLock lock) {
-        lock.unlock();
-    }
-
-    public <T> T executeWithLock(Long cowalkPostId, Supplier<T> task) throws InterruptedException {
-        RLock lock = tryFairLock(cowalkPostId);
-
-        try {
-            return task.get();
-        } finally {
-            unlock(lock);
         }
     }
 }

--- a/dongsan-core/domain-redis/src/main/java/com/dongsan/domain/domains/cowalk/CowalkPostLockService.java
+++ b/dongsan-core/domain-redis/src/main/java/com/dongsan/domain/domains/cowalk/CowalkPostLockService.java
@@ -28,19 +28,16 @@ public class CowalkPostLockService {
         long leaseTime = 2;
 
         RLock lock = getFairLock(cowalkPostId);
-        boolean isLocked = false;
+
+        boolean isLocked = lock.tryLock(waitTime, leaseTime, TimeUnit.SECONDS);
+        if (!isLocked) {
+            throw new InterruptedException("CowalkPostLockService : 락 획득 실패 " + cowalkPostId);
+        }
 
         try {
-            isLocked = lock.tryLock(waitTime, leaseTime, TimeUnit.SECONDS);
-            if (!isLocked) {
-                throw new InterruptedException("CowalkPostLockService : 락 획득 실패 " + cowalkPostId);
-            }
-
             return task.get();
         } finally {
-            if (isLocked && lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
+            lock.unlock();
         }
     }
 }

--- a/dongsan-core/domain-redis/src/main/java/com/dongsan/domain/domains/cowalk/CowalkPostLockService.java
+++ b/dongsan-core/domain-redis/src/main/java/com/dongsan/domain/domains/cowalk/CowalkPostLockService.java
@@ -19,10 +19,6 @@ public class CowalkPostLockService {
         return lockRepository.getFairLock(key);
     }
 
-    public void unlock(RLock lock) {
-        lock.unlock();
-    }
-
     public <T> T executeWithFairLock(Long cowalkPostId, Supplier<T> task) throws InterruptedException {
         long waitTime = 10;
         long leaseTime = 2;

--- a/dongsan-core/domain-redis/src/main/java/com/dongsan/domain/domains/cowalk/CowalkPostLockService.java
+++ b/dongsan-core/domain-redis/src/main/java/com/dongsan/domain/domains/cowalk/CowalkPostLockService.java
@@ -1,0 +1,48 @@
+package com.dongsan.domain.domains.cowalk;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.redisson.api.RLock;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CowalkPostLockService {
+    private final LockRepository lockRepository;
+
+    public CowalkPostLockService(LockRepository cowalkPostLockRepository) {
+        this.lockRepository = cowalkPostLockRepository;
+    }
+
+    public RLock getFairLock(Long cowalkPostId) {
+        String key = "cowalkPost:lock:" + cowalkPostId;
+        return lockRepository.getFairLock(key);
+    }
+
+    public RLock tryFairLock(Long cowalkPostId) throws InterruptedException {
+        long waitTime = 10;
+        long leaseTime = 2;
+
+        RLock lock = getFairLock(cowalkPostId);
+
+        if (lock.tryLock(waitTime, leaseTime, TimeUnit.SECONDS)) {
+            return lock;
+        } else {
+            throw new InterruptedException("CowalkPostLockService : 락 획득 실패: " + cowalkPostId);
+        }
+    }
+
+    public void unlock(RLock lock) {
+        lock.unlock();
+    }
+
+    public <T> T executeWithLock(Long cowalkPostId, Supplier<T> task) throws InterruptedException {
+        RLock lock = tryFairLock(cowalkPostId);
+
+        try {
+            return task.get();
+        } finally {
+            unlock(lock);
+        }
+    }
+}

--- a/dongsan-core/domain-redis/src/main/java/com/dongsan/domain/domains/cowalk/CowalkPostLockService.java
+++ b/dongsan-core/domain-redis/src/main/java/com/dongsan/domain/domains/cowalk/CowalkPostLockService.java
@@ -28,15 +28,19 @@ public class CowalkPostLockService {
         long leaseTime = 2;
 
         RLock lock = getFairLock(cowalkPostId);
+        boolean isLocked = false;
 
-        if (lock.tryLock(waitTime, leaseTime, TimeUnit.SECONDS)) {
-            try {
-                return task.get();
-            } finally {
-                unlock(lock);
+        try {
+            isLocked = lock.tryLock(waitTime, leaseTime, TimeUnit.SECONDS);
+            if (!isLocked) {
+                throw new InterruptedException("CowalkPostLockService : 락 획득 실패 " + cowalkPostId);
             }
-        } else {
-            throw new InterruptedException("CowalkPostLockService : 락 획득 실패: " + cowalkPostId);
+
+            return task.get();
+        } finally {
+            if (isLocked && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
         }
     }
 }

--- a/dongsan-core/domain-redis/src/main/java/com/dongsan/domain/domains/cowalk/LockRepository.java
+++ b/dongsan-core/domain-redis/src/main/java/com/dongsan/domain/domains/cowalk/LockRepository.java
@@ -1,0 +1,18 @@
+package com.dongsan.domain.domains.cowalk;
+
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class LockRepository {
+	private final RedissonClient redissonClient;
+
+	public LockRepository(RedissonClient redissonClient) {
+		this.redissonClient = redissonClient;
+	}
+
+	public RLock getFairLock(String key) {
+		return redissonClient.getFairLock(key);
+	}
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostController.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostController.java
@@ -3,6 +3,7 @@ package com.dongsan.api.domains.cowalk;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.dongsan.api.domains.auth.CustomAuthUser;
 import com.dongsan.api.domains.cowalk.dto.request.CreateCowalkPostRequest;
+import com.dongsan.api.domains.cowalk.dto.response.CowalkPostDetailResponse;
 import com.dongsan.api.domains.cowalk.dto.response.CreateCowalkPostResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -38,5 +40,17 @@ public class CowalkPostController {
 		Long cowalkId = cowalkPostFacade.saveCowalkPost(createCowalkPostRequest, crewId,
 			customOAuth2User.getMemberId());
 		return ResponseEntity.ok(new CreateCowalkPostResponse(cowalkId));
+	}
+
+	@Operation(summary = "같이 산책 상세조회")
+	@GetMapping("/{crewId}/cowalk/{cowalkId}")
+	public ResponseEntity<CowalkPostDetailResponse> getCowalkPost(
+		@PathVariable Long crewId,
+		@PathVariable Long cowalkId,
+		@AuthenticationPrincipal CustomAuthUser customOAuth2User
+	) {
+		CowalkPostDetailResponse cowalkPostDetail
+			= cowalkPostFacade.getCowalkPostDetail(cowalkId, crewId, customOAuth2User.getMemberId());
+		return ResponseEntity.ok(cowalkPostDetail);
 	}
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostController.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostController.java
@@ -28,56 +28,56 @@ import jakarta.validation.Valid;
 @Validated
 @Tag(name = "같이 산책")
 public class CowalkPostController {
-	private final CowalkPostFacade cowalkPostFacade;
+    private final CowalkPostFacade cowalkPostFacade;
 
-	public CowalkPostController(CowalkPostFacade cowalkPostFacade) {
-		this.cowalkPostFacade = cowalkPostFacade;
-	}
+    public CowalkPostController(CowalkPostFacade cowalkPostFacade) {
+        this.cowalkPostFacade = cowalkPostFacade;
+    }
 
-	@Operation(summary = "같이 산책 생성")
-	@PostMapping("/{crewId}/cowalk")
-	public ResponseEntity<CreateCowalkPostResponse> createCowalkPost(
-		@PathVariable Long crewId,
-		@Valid @RequestBody CreateCowalkPostRequest createCowalkPostRequest,
-		@AuthenticationPrincipal CustomAuthUser customOAuth2User
-	) {
-		Long cowalkId = cowalkPostFacade.saveCowalkPost(createCowalkPostRequest, crewId,
-			customOAuth2User.getMemberId());
-		return ResponseEntity.ok(new CreateCowalkPostResponse(cowalkId));
-	}
+    @Operation(summary = "같이 산책 생성")
+    @PostMapping("/{crewId}/cowalk")
+    public ResponseEntity<CreateCowalkPostResponse> createCowalkPost(
+            @PathVariable Long crewId,
+            @Valid @RequestBody CreateCowalkPostRequest createCowalkPostRequest,
+            @AuthenticationPrincipal CustomAuthUser customOAuth2User
+    ) {
+        Long cowalkId = cowalkPostFacade.saveCowalkPost(createCowalkPostRequest, crewId,
+                customOAuth2User.getMemberId());
+        return ResponseEntity.ok(new CreateCowalkPostResponse(cowalkId));
+    }
 
-	@Operation(summary = "같이 산책 상세조회")
-	@GetMapping("/{crewId}/cowalk/{cowalkId}")
-	public ResponseEntity<CowalkPostDetailResponse> getCowalkPost(
-		@PathVariable Long crewId,
-		@PathVariable Long cowalkId,
-		@AuthenticationPrincipal CustomAuthUser customOAuth2User
-	) {
-		CowalkPostDetailResponse cowalkPostDetail
-			= cowalkPostFacade.getCowalkPostDetail(cowalkId, crewId, customOAuth2User.getMemberId());
-		return ResponseEntity.ok(cowalkPostDetail);
-	}
+    @Operation(summary = "같이 산책 상세조회")
+    @GetMapping("/{crewId}/cowalk/{cowalkId}")
+    public ResponseEntity<CowalkPostDetailResponse> getCowalkPost(
+            @PathVariable Long crewId,
+            @PathVariable Long cowalkId,
+            @AuthenticationPrincipal CustomAuthUser customOAuth2User
+    ) {
+        CowalkPostDetailResponse cowalkPostDetail
+                = cowalkPostFacade.getCowalkPostDetail(cowalkId, crewId, customOAuth2User.getMemberId());
+        return ResponseEntity.ok(cowalkPostDetail);
+    }
 
-	@Operation(summary = "같이 산책 참여")
-	@PostMapping("/{crewId}/cowalk/{cowalkId}/join")
-	public ResponseEntity<JoinCowalkParticipantResponse> joinParticipant(
-		@PathVariable Long crewId,
-		@PathVariable Long cowalkId,
-		@AuthenticationPrincipal CustomAuthUser customOAuth2User
-	) {
-		Long participantId
-			= cowalkPostFacade.joinCowalkPost(crewId, cowalkId, customOAuth2User.getMemberId());
-		return ResponseEntity.ok(new JoinCowalkParticipantResponse(participantId));
-	}
+    @Operation(summary = "같이 산책 참여")
+    @PostMapping("/{crewId}/cowalk/{cowalkId}/join")
+    public ResponseEntity<JoinCowalkParticipantResponse> joinParticipant(
+            @PathVariable Long crewId,
+            @PathVariable Long cowalkId,
+            @AuthenticationPrincipal CustomAuthUser customOAuth2User
+    ) {
+        Long participantId
+                = cowalkPostFacade.joinCowalkPost(crewId, cowalkId, customOAuth2User.getMemberId());
+        return ResponseEntity.ok(new JoinCowalkParticipantResponse(participantId));
+    }
 
-	@Operation(summary = "같이 산책 목록 조회")
-	@GetMapping("/{crewId}/cowalk")
-	public ResponseEntity<CursorPage<CowalkPostsResponse>> getCowalkPosts(
-		@PathVariable Long crewId,
-		@RequestParam(required = false) Long lastId,
-		@RequestParam(defaultValue = "10") Integer size
-	) {
-		CursorPage<CowalkPostsResponse> cowalkPosts = cowalkPostFacade.getCowalkPosts(crewId, size, lastId);
-		return ResponseEntity.ok(cowalkPosts);
-	}
+    @Operation(summary = "같이 산책 목록 조회")
+    @GetMapping("/{crewId}/cowalk")
+    public ResponseEntity<CursorPage<CowalkPostsResponse>> getCowalkPosts(
+            @PathVariable Long crewId,
+            @RequestParam(required = false) Long lastId,
+            @RequestParam(defaultValue = "10") Integer size
+    ) {
+        CursorPage<CowalkPostsResponse> cowalkPosts = cowalkPostFacade.getCowalkPosts(crewId, size, lastId);
+        return ResponseEntity.ok(cowalkPosts);
+    }
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostController.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostController.java
@@ -8,13 +8,16 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dongsan.api.domains.auth.CustomAuthUser;
 import com.dongsan.api.domains.cowalk.dto.request.CreateCowalkPostRequest;
 import com.dongsan.api.domains.cowalk.dto.response.CowalkPostDetailResponse;
+import com.dongsan.api.domains.cowalk.dto.response.CowalkPostsResponse;
 import com.dongsan.api.domains.cowalk.dto.response.CreateCowalkPostResponse;
 import com.dongsan.api.domains.cowalk.dto.response.JoinCowalkParticipantResponse;
+import com.dongsan.domain.support.util.CursorPage;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -65,5 +68,16 @@ public class CowalkPostController {
 		Long participantId
 			= cowalkPostFacade.joinCowalkPost(crewId, cowalkId, customOAuth2User.getMemberId());
 		return ResponseEntity.ok(new JoinCowalkParticipantResponse(participantId));
+	}
+
+	@Operation(summary = "같이 산책 목록 조회")
+	@GetMapping("/{crewId}/cowalk")
+	public ResponseEntity<CursorPage<CowalkPostsResponse>> getCowalkPosts(
+		@PathVariable Long crewId,
+		@RequestParam(required = false) Long lastId,
+		@RequestParam(defaultValue = "10") Integer size
+	) {
+		CursorPage<CowalkPostsResponse> cowalkPosts = cowalkPostFacade.getCowalkPosts(crewId, size, lastId);
+		return ResponseEntity.ok(cowalkPosts);
 	}
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostController.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostController.java
@@ -14,6 +14,7 @@ import com.dongsan.api.domains.auth.CustomAuthUser;
 import com.dongsan.api.domains.cowalk.dto.request.CreateCowalkPostRequest;
 import com.dongsan.api.domains.cowalk.dto.response.CowalkPostDetailResponse;
 import com.dongsan.api.domains.cowalk.dto.response.CreateCowalkPostResponse;
+import com.dongsan.api.domains.cowalk.dto.response.JoinCowalkParticipantResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -52,5 +53,17 @@ public class CowalkPostController {
 		CowalkPostDetailResponse cowalkPostDetail
 			= cowalkPostFacade.getCowalkPostDetail(cowalkId, crewId, customOAuth2User.getMemberId());
 		return ResponseEntity.ok(cowalkPostDetail);
+	}
+
+	@Operation(summary = "같이 산책 참여")
+	@PostMapping("/{crewId}/cowalk/{cowalkId}/join")
+	public ResponseEntity<JoinCowalkParticipantResponse> joinParticipant(
+		@PathVariable Long crewId,
+		@PathVariable Long cowalkId,
+		@AuthenticationPrincipal CustomAuthUser customOAuth2User
+	) {
+		Long participantId
+			= cowalkPostFacade.joinCowalkPost(crewId, cowalkId, customOAuth2User.getMemberId());
+		return ResponseEntity.ok(new JoinCowalkParticipantResponse(participantId));
 	}
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostController.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostController.java
@@ -1,0 +1,42 @@
+package com.dongsan.api.domains.cowalk;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dongsan.api.domains.auth.CustomAuthUser;
+import com.dongsan.api.domains.cowalk.dto.request.CreateCowalkPostRequest;
+import com.dongsan.api.domains.cowalk.dto.response.CreateCowalkPostResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/crews")
+@Validated
+@Tag(name = "같이 산책")
+public class CowalkPostController {
+	private final CowalkPostFacade cowalkPostFacade;
+
+	public CowalkPostController(CowalkPostFacade cowalkPostFacade) {
+		this.cowalkPostFacade = cowalkPostFacade;
+	}
+
+	@Operation(summary = "같이 산책 생성")
+	@PostMapping("/{crewId}/cowalk")
+	public ResponseEntity<CreateCowalkPostResponse> createCowalkPost(
+		@PathVariable Long crewId,
+		@Valid @RequestBody CreateCowalkPostRequest createCowalkPostRequest,
+		@AuthenticationPrincipal CustomAuthUser customOAuth2User
+	) {
+		Long cowalkId = cowalkPostFacade.saveCowalkPost(createCowalkPostRequest, crewId,
+			customOAuth2User.getMemberId());
+		return ResponseEntity.ok(new CreateCowalkPostResponse(cowalkId));
+	}
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
@@ -67,12 +67,13 @@ public class CowalkPostFacade {
     public Long joinCowalkPost(Long crewId, Long cowalkPostId, Long memberId) {
         crewMemberRdbService.validateIsCrewMember(crewId, memberId);
         try {
-            return cowalkPostLockService.executeWithLock(cowalkPostId, () -> {
+            return cowalkPostLockService.executeWithFairLock(cowalkPostId, () -> {
                 Integer participantCount = cowalkParticipantRdbService.countByCowalkPostId(cowalkPostId);
                 cowalkPostRdbService.validJoin(cowalkPostId, participantCount);
                 return cowalkParticipantRdbService.save(memberId, cowalkPostId);
             });
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new CoreException(CoreErrorCode.COWALK_LOCK_FAIL);
         }
     }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
@@ -61,7 +61,8 @@ public class CowalkPostFacade {
 
 	public Long joinCowalkPost(Long crewId, Long cowalkPostId, Long memberId) {
 		crewMemberRdbService.validateIsCrewMember(crewId, memberId);
-		cowalkParticipantRdbService.validAlreadyJoin(memberId, cowalkPostId);
+		Integer participantCount = cowalkParticipantRdbService.countByCowalkPostId(cowalkPostId);
+		cowalkPostRdbService.validCapacity(cowalkPostId, participantCount);
 		return cowalkParticipantRdbService.save(memberId, cowalkPostId);
 	}
 

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
@@ -7,20 +7,27 @@ import com.dongsan.api.domains.cowalk.dto.request.CreateCowalkPostRequest;
 import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
 import com.dongsan.domain.domains.cowalk.service.CowalkParticipantRdbService;
 import com.dongsan.domain.domains.cowalk.service.CowalkPostRdbService;
+import com.dongsan.domain.domains.crew.service.CrewMemberRdbService;
 
 @Service
 @Transactional
 public class CowalkPostFacade {
 	private final CowalkParticipantRdbService cowalkParticipantRdbService;
 	private final CowalkPostRdbService cowalkPostRdbService;
+	private final CrewMemberRdbService crewMemberRdbService;
 
-	public CowalkPostFacade(CowalkParticipantRdbService cowalkParticipantRdbService,
-		CowalkPostRdbService cowalkPostRdbService) {
+	public CowalkPostFacade(
+		CowalkParticipantRdbService cowalkParticipantRdbService,
+		CowalkPostRdbService cowalkPostRdbService,
+		CrewMemberRdbService crewMemberRdbService
+	) {
 		this.cowalkParticipantRdbService = cowalkParticipantRdbService;
 		this.cowalkPostRdbService = cowalkPostRdbService;
+		this.crewMemberRdbService = crewMemberRdbService;
 	}
 
 	public Long saveCowalkPost(CreateCowalkPostRequest createCowalkPostRequest, Long crewId, Long memberId) {
+		crewMemberRdbService.validateIsCrewMember(crewId, memberId);
 		CreateCowalkPostCommand command = createCowalkPostRequest.toCreateCowalkPostCommand(crewId, memberId);
 		Long cowalkPostId = cowalkPostRdbService.save(command);
 		cowalkParticipantRdbService.save(memberId, cowalkPostId);

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
@@ -1,0 +1,29 @@
+package com.dongsan.api.domains.cowalk;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dongsan.api.domains.cowalk.dto.request.CreateCowalkPostRequest;
+import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
+import com.dongsan.domain.domains.cowalk.service.CowalkParticipantRdbService;
+import com.dongsan.domain.domains.cowalk.service.CowalkPostRdbService;
+
+@Service
+@Transactional
+public class CowalkPostFacade {
+	private final CowalkParticipantRdbService cowalkParticipantRdbService;
+	private final CowalkPostRdbService cowalkPostRdbService;
+
+	public CowalkPostFacade(CowalkParticipantRdbService cowalkParticipantRdbService,
+		CowalkPostRdbService cowalkPostRdbService) {
+		this.cowalkParticipantRdbService = cowalkParticipantRdbService;
+		this.cowalkPostRdbService = cowalkPostRdbService;
+	}
+
+	public Long saveCowalkPost(CreateCowalkPostRequest createCowalkPostRequest, Long crewId, Long memberId) {
+		CreateCowalkPostCommand command = createCowalkPostRequest.toCreateCowalkPostCommand(crewId, memberId);
+		Long cowalkPostId = cowalkPostRdbService.save(command);
+		cowalkParticipantRdbService.save(memberId, cowalkPostId);
+		return cowalkPostId;
+	}
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
@@ -4,26 +4,37 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dongsan.api.domains.cowalk.dto.request.CreateCowalkPostRequest;
+import com.dongsan.api.domains.cowalk.dto.response.CowalkPostDetailResponse;
 import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
+import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
+import com.dongsan.domain.domains.cowalk.service.CowalkCommentRdbService;
 import com.dongsan.domain.domains.cowalk.service.CowalkParticipantRdbService;
 import com.dongsan.domain.domains.cowalk.service.CowalkPostRdbService;
 import com.dongsan.domain.domains.crew.service.CrewMemberRdbService;
+import com.dongsan.domain.domains.member.Member;
+import com.dongsan.domain.domains.member.MemberService;
 
 @Service
 @Transactional
 public class CowalkPostFacade {
 	private final CowalkParticipantRdbService cowalkParticipantRdbService;
+	private final CowalkCommentRdbService cowalkCommentRdbService;
 	private final CowalkPostRdbService cowalkPostRdbService;
 	private final CrewMemberRdbService crewMemberRdbService;
+	private final MemberService memberService;
 
 	public CowalkPostFacade(
 		CowalkParticipantRdbService cowalkParticipantRdbService,
+		CowalkCommentRdbService cowalkCommentRdbService,
 		CowalkPostRdbService cowalkPostRdbService,
-		CrewMemberRdbService crewMemberRdbService
+		CrewMemberRdbService crewMemberRdbService,
+		MemberService memberService
 	) {
 		this.cowalkParticipantRdbService = cowalkParticipantRdbService;
+		this.cowalkCommentRdbService = cowalkCommentRdbService;
 		this.cowalkPostRdbService = cowalkPostRdbService;
 		this.crewMemberRdbService = crewMemberRdbService;
+		this.memberService = memberService;
 	}
 
 	public Long saveCowalkPost(CreateCowalkPostRequest createCowalkPostRequest, Long crewId, Long memberId) {
@@ -32,5 +43,14 @@ public class CowalkPostFacade {
 		Long cowalkPostId = cowalkPostRdbService.save(command);
 		cowalkParticipantRdbService.save(memberId, cowalkPostId);
 		return cowalkPostId;
+	}
+
+	public CowalkPostDetailResponse getCowalkPostDetail(Long cowalkPostId, Long crewId, Long memberId) {
+		crewMemberRdbService.validateIsCrewMember(crewId, memberId);
+		CowalkPost cowalkPost = cowalkPostRdbService.getCowalkPost(cowalkPostId);
+		Integer participantCount = cowalkParticipantRdbService.countByCowalkPostId(cowalkPostId);
+		Integer commentCount = cowalkCommentRdbService.countByCowalkPostId(cowalkPostId);
+		Member member = memberService.getMember(memberId);
+		return new CowalkPostDetailResponse(cowalkPost, participantCount, commentCount, member);
 	}
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
@@ -1,10 +1,14 @@
 package com.dongsan.api.domains.cowalk;
 
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dongsan.api.domains.cowalk.dto.request.CreateCowalkPostRequest;
 import com.dongsan.api.domains.cowalk.dto.response.CowalkPostDetailResponse;
+import com.dongsan.api.domains.cowalk.dto.response.CowalkPostsResponse;
 import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
 import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
 import com.dongsan.domain.domains.cowalk.service.CowalkCommentRdbService;
@@ -13,6 +17,7 @@ import com.dongsan.domain.domains.cowalk.service.CowalkPostRdbService;
 import com.dongsan.domain.domains.crew.service.CrewMemberRdbService;
 import com.dongsan.domain.domains.member.Member;
 import com.dongsan.domain.domains.member.MemberService;
+import com.dongsan.domain.support.util.CursorPage;
 
 @Service
 @Transactional
@@ -58,5 +63,30 @@ public class CowalkPostFacade {
 		crewMemberRdbService.validateIsCrewMember(crewId, memberId);
 		cowalkParticipantRdbService.validAlreadyJoin(memberId, cowalkPostId);
 		return cowalkParticipantRdbService.save(memberId, cowalkPostId);
+	}
+
+	public CursorPage<CowalkPostsResponse> getCowalkPosts(Long crewId, Integer size, Long lastId) {
+		CursorPage<CowalkPost> cowalkPosts = cowalkPostRdbService.getCowalkPosts(size, lastId, crewId);
+		List<CowalkPost> cowalkPostList = cowalkPosts.getData();
+
+		List<Long> memberIds = cowalkPostList.stream()
+			.map(CowalkPost::getMemberId)
+			.toList();
+
+		List<Long> cowalkPostIds = cowalkPostList.stream()
+			.map(CowalkPost::getId)
+			.toList();
+
+		Map<Long, Member> memberMap = memberService.getMemberMap(memberIds);
+		Map<Long, Integer> memberCountMap = cowalkParticipantRdbService.countByCowalkPostIds(cowalkPostIds);
+		Map<Long, Integer> commentCountMap = cowalkCommentRdbService.countByCowalkPostIds(cowalkPostIds);
+		List<CowalkPostsResponse> cowalkPostsResponseList = CowalkPostsResponse.from(
+			cowalkPostList,
+			memberMap,
+			memberCountMap,
+			commentCountMap
+		);
+
+		return new CursorPage<>(cowalkPostsResponseList, cowalkPosts.getHasNext());
 	}
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
@@ -53,4 +53,10 @@ public class CowalkPostFacade {
 		Member member = memberService.getMember(memberId);
 		return new CowalkPostDetailResponse(cowalkPost, participantCount, commentCount, member);
 	}
+
+	public Long joinCowalkPost(Long crewId, Long cowalkPostId, Long memberId) {
+		crewMemberRdbService.validateIsCrewMember(crewId, memberId);
+		cowalkParticipantRdbService.validAlreadyJoin(memberId, cowalkPostId);
+		return cowalkParticipantRdbService.save(memberId, cowalkPostId);
+	}
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.dongsan.api.domains.cowalk.dto.request.CreateCowalkPostRequest;
 import com.dongsan.api.domains.cowalk.dto.response.CowalkPostDetailResponse;
 import com.dongsan.api.domains.cowalk.dto.response.CowalkPostsResponse;
+import com.dongsan.domain.domains.cowalk.CowalkPostLockService;
 import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
 import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
 import com.dongsan.domain.domains.cowalk.service.CowalkCommentRdbService;
@@ -17,77 +18,87 @@ import com.dongsan.domain.domains.cowalk.service.CowalkPostRdbService;
 import com.dongsan.domain.domains.crew.service.CrewMemberRdbService;
 import com.dongsan.domain.domains.member.Member;
 import com.dongsan.domain.domains.member.MemberService;
+import com.dongsan.domain.support.error.CoreErrorCode;
+import com.dongsan.domain.support.error.CoreException;
 import com.dongsan.domain.support.util.CursorPage;
 
 @Service
 public class CowalkPostFacade {
-	private final CowalkParticipantRdbService cowalkParticipantRdbService;
-	private final CowalkCommentRdbService cowalkCommentRdbService;
-	private final CowalkPostRdbService cowalkPostRdbService;
-	private final CrewMemberRdbService crewMemberRdbService;
-	private final MemberService memberService;
+    private final CowalkParticipantRdbService cowalkParticipantRdbService;
+    private final CowalkCommentRdbService cowalkCommentRdbService;
+    private final CowalkPostRdbService cowalkPostRdbService;
+    private final CrewMemberRdbService crewMemberRdbService;
+    private final MemberService memberService;
+    private final CowalkPostLockService cowalkPostLockService;
 
-	public CowalkPostFacade(
-		CowalkParticipantRdbService cowalkParticipantRdbService,
-		CowalkCommentRdbService cowalkCommentRdbService,
-		CowalkPostRdbService cowalkPostRdbService,
-		CrewMemberRdbService crewMemberRdbService,
-		MemberService memberService
-	) {
-		this.cowalkParticipantRdbService = cowalkParticipantRdbService;
-		this.cowalkCommentRdbService = cowalkCommentRdbService;
-		this.cowalkPostRdbService = cowalkPostRdbService;
-		this.crewMemberRdbService = crewMemberRdbService;
-		this.memberService = memberService;
-	}
+    public CowalkPostFacade(
+            CowalkParticipantRdbService cowalkParticipantRdbService,
+            CowalkCommentRdbService cowalkCommentRdbService,
+            CowalkPostRdbService cowalkPostRdbService,
+            CrewMemberRdbService crewMemberRdbService,
+            MemberService memberService, CowalkPostLockService cowalkPostLockService
+    ) {
+        this.cowalkParticipantRdbService = cowalkParticipantRdbService;
+        this.cowalkCommentRdbService = cowalkCommentRdbService;
+        this.cowalkPostRdbService = cowalkPostRdbService;
+        this.crewMemberRdbService = crewMemberRdbService;
+        this.memberService = memberService;
+        this.cowalkPostLockService = cowalkPostLockService;
+    }
 
-	@Transactional
-	public Long saveCowalkPost(CreateCowalkPostRequest createCowalkPostRequest, Long crewId, Long memberId) {
-		crewMemberRdbService.validateIsCrewMember(crewId, memberId);
-		CreateCowalkPostCommand command = createCowalkPostRequest.toCreateCowalkPostCommand(crewId, memberId);
-		Long cowalkPostId = cowalkPostRdbService.save(command);
-		cowalkParticipantRdbService.save(memberId, cowalkPostId);
-		return cowalkPostId;
-	}
+    @Transactional
+    public Long saveCowalkPost(CreateCowalkPostRequest createCowalkPostRequest, Long crewId, Long memberId) {
+        crewMemberRdbService.validateIsCrewMember(crewId, memberId);
+        CreateCowalkPostCommand command = createCowalkPostRequest.toCreateCowalkPostCommand(crewId, memberId);
+        Long cowalkPostId = cowalkPostRdbService.save(command);
+        cowalkParticipantRdbService.save(memberId, cowalkPostId);
+        return cowalkPostId;
+    }
 
-	public CowalkPostDetailResponse getCowalkPostDetail(Long cowalkPostId, Long crewId, Long memberId) {
-		crewMemberRdbService.validateIsCrewMember(crewId, memberId);
-		CowalkPost cowalkPost = cowalkPostRdbService.getCowalkPost(cowalkPostId);
-		Integer participantCount = cowalkParticipantRdbService.countByCowalkPostId(cowalkPostId);
-		Integer commentCount = cowalkCommentRdbService.countByCowalkPostId(cowalkPostId);
-		Member member = memberService.getMember(memberId);
-		return new CowalkPostDetailResponse(cowalkPost, participantCount, commentCount, member);
-	}
+    public CowalkPostDetailResponse getCowalkPostDetail(Long cowalkPostId, Long crewId, Long memberId) {
+        crewMemberRdbService.validateIsCrewMember(crewId, memberId);
+        CowalkPost cowalkPost = cowalkPostRdbService.getCowalkPost(cowalkPostId);
+        Integer participantCount = cowalkParticipantRdbService.countByCowalkPostId(cowalkPostId);
+        Integer commentCount = cowalkCommentRdbService.countByCowalkPostId(cowalkPostId);
+        Member member = memberService.getMember(memberId);
+        return new CowalkPostDetailResponse(cowalkPost, participantCount, commentCount, member);
+    }
 
-	public synchronized Long joinCowalkPost(Long crewId, Long cowalkPostId, Long memberId) {
-		crewMemberRdbService.validateIsCrewMember(crewId, memberId);
-		Integer participantCount = cowalkParticipantRdbService.countByCowalkPostId(cowalkPostId);
-		cowalkPostRdbService.validJoin(cowalkPostId, participantCount);
-		return cowalkParticipantRdbService.save(memberId, cowalkPostId);
-	}
+    public Long joinCowalkPost(Long crewId, Long cowalkPostId, Long memberId) {
+        crewMemberRdbService.validateIsCrewMember(crewId, memberId);
+        try {
+            return cowalkPostLockService.executeWithLock(cowalkPostId, () -> {
+                Integer participantCount = cowalkParticipantRdbService.countByCowalkPostId(cowalkPostId);
+                cowalkPostRdbService.validJoin(cowalkPostId, participantCount);
+                return cowalkParticipantRdbService.save(memberId, cowalkPostId);
+            });
+        } catch (InterruptedException e) {
+            throw new CoreException(CoreErrorCode.COWALK_LOCK_FAIL);
+        }
+    }
 
-	public CursorPage<CowalkPostsResponse> getCowalkPosts(Long crewId, Integer size, Long lastId) {
-		CursorPage<CowalkPost> cowalkPosts = cowalkPostRdbService.getCowalkPosts(size, lastId, crewId);
-		List<CowalkPost> cowalkPostList = cowalkPosts.getData();
+    public CursorPage<CowalkPostsResponse> getCowalkPosts(Long crewId, Integer size, Long lastId) {
+        CursorPage<CowalkPost> cowalkPosts = cowalkPostRdbService.getCowalkPosts(size, lastId, crewId);
+        List<CowalkPost> cowalkPostList = cowalkPosts.getData();
 
-		List<Long> memberIds = cowalkPostList.stream()
-			.map(CowalkPost::getMemberId)
-			.toList();
+        List<Long> memberIds = cowalkPostList.stream()
+                .map(CowalkPost::getMemberId)
+                .toList();
 
-		List<Long> cowalkPostIds = cowalkPostList.stream()
-			.map(CowalkPost::getId)
-			.toList();
+        List<Long> cowalkPostIds = cowalkPostList.stream()
+                .map(CowalkPost::getId)
+                .toList();
 
-		Map<Long, Member> memberMap = memberService.getMemberMap(memberIds);
-		Map<Long, Integer> memberCountMap = cowalkParticipantRdbService.countByCowalkPostIds(cowalkPostIds);
-		Map<Long, Integer> commentCountMap = cowalkCommentRdbService.countByCowalkPostIds(cowalkPostIds);
-		List<CowalkPostsResponse> cowalkPostsResponseList = CowalkPostsResponse.from(
-			cowalkPostList,
-			memberMap,
-			memberCountMap,
-			commentCountMap
-		);
+        Map<Long, Member> memberMap = memberService.getMemberMap(memberIds);
+        Map<Long, Integer> memberCountMap = cowalkParticipantRdbService.countByCowalkPostIds(cowalkPostIds);
+        Map<Long, Integer> commentCountMap = cowalkCommentRdbService.countByCowalkPostIds(cowalkPostIds);
+        List<CowalkPostsResponse> cowalkPostsResponseList = CowalkPostsResponse.from(
+                cowalkPostList,
+                memberMap,
+                memberCountMap,
+                commentCountMap
+        );
 
-		return new CursorPage<>(cowalkPostsResponseList, cowalkPosts.getHasNext());
-	}
+        return new CursorPage<>(cowalkPostsResponseList, cowalkPosts.getHasNext());
+    }
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
@@ -20,7 +20,6 @@ import com.dongsan.domain.domains.member.MemberService;
 import com.dongsan.domain.support.util.CursorPage;
 
 @Service
-@Transactional
 public class CowalkPostFacade {
 	private final CowalkParticipantRdbService cowalkParticipantRdbService;
 	private final CowalkCommentRdbService cowalkCommentRdbService;
@@ -42,6 +41,7 @@ public class CowalkPostFacade {
 		this.memberService = memberService;
 	}
 
+	@Transactional
 	public Long saveCowalkPost(CreateCowalkPostRequest createCowalkPostRequest, Long crewId, Long memberId) {
 		crewMemberRdbService.validateIsCrewMember(crewId, memberId);
 		CreateCowalkPostCommand command = createCowalkPostRequest.toCreateCowalkPostCommand(crewId, memberId);
@@ -59,10 +59,10 @@ public class CowalkPostFacade {
 		return new CowalkPostDetailResponse(cowalkPost, participantCount, commentCount, member);
 	}
 
-	public Long joinCowalkPost(Long crewId, Long cowalkPostId, Long memberId) {
+	public synchronized Long joinCowalkPost(Long crewId, Long cowalkPostId, Long memberId) {
 		crewMemberRdbService.validateIsCrewMember(crewId, memberId);
 		Integer participantCount = cowalkParticipantRdbService.countByCowalkPostId(cowalkPostId);
-		cowalkPostRdbService.validCapacity(cowalkPostId, participantCount);
+		cowalkPostRdbService.validJoin(cowalkPostId, participantCount);
 		return cowalkParticipantRdbService.save(memberId, cowalkPostId);
 	}
 

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/request/CreateCowalkPostRequest.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/request/CreateCowalkPostRequest.java
@@ -11,26 +11,26 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 public record CreateCowalkPostRequest(
-	@NotNull(message = "산책 날짜를 입력해주세요")
-	LocalDate date,
+        @NotNull(message = "산책 날짜를 입력해주세요")
+        LocalDate date,
 
-	@Schema(type = "string", example = "08:00:00", description = "산책 시작 시간")
-	@NotNull(message = "산책 시간을 입력해주세요")
-	LocalTime time,
+        @Schema(type = "string", example = "08:00:00", description = "산책 시작 시간")
+        @NotNull(message = "산책 시간을 입력해주세요")
+        LocalTime time,
 
-	@NotNull(message = "인원 제한 여부를 입력해주세요")
-	Boolean limitEnable,
+        @NotNull(message = "인원 제한 여부를 입력해주세요")
+        Boolean limitEnable,
 
-	@Range(min = 2, max = 100, message = "인원은 2~100명까지 가능합니다")
-	Integer memberLimit
+        @Range(min = 2, max = 100, message = "인원은 2~100명까지 가능합니다")
+        Integer memberLimit
 ) {
-	public CreateCowalkPostCommand toCreateCowalkPostCommand(Long crewId, Long memberId) {
-		return new CreateCowalkPostCommand(
-			crewId,
-			memberId,
-			date,
-			time,
-			memberLimit
-		);
-	}
+    public CreateCowalkPostCommand toCreateCowalkPostCommand(Long crewId, Long memberId) {
+        return new CreateCowalkPostCommand(
+                crewId,
+                memberId,
+                date,
+                time,
+                memberLimit
+        );
+    }
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/request/CreateCowalkPostRequest.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/request/CreateCowalkPostRequest.java
@@ -1,0 +1,36 @@
+package com.dongsan.api.domains.cowalk.dto.request;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import org.hibernate.validator.constraints.Range;
+
+import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateCowalkPostRequest(
+	@NotNull(message = "산책 날짜를 입력해주세요")
+	LocalDate date,
+
+	@Schema(type = "string", example = "08:00:00", description = "산책 시작 시간")
+	@NotNull(message = "산책 시간을 입력해주세요")
+	LocalTime time,
+
+	@NotNull(message = "인원 제한 여부를 입력해주세요")
+	Boolean limitEnable,
+
+	@Range(min = 2, max = 100, message = "인원은 2~100명까지 가능합니다")
+	Integer memberLimit
+) {
+	public CreateCowalkPostCommand toCreateCowalkPostCommand(Long crewId, Long memberId) {
+		return new CreateCowalkPostCommand(
+			crewId,
+			memberId,
+			date,
+			time,
+			memberLimit
+		);
+	}
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CowalkPostDetailResponse.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CowalkPostDetailResponse.java
@@ -8,29 +8,29 @@ import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
 import com.dongsan.domain.domains.member.Member;
 
 public record CowalkPostDetailResponse(
-	Long cowalkId,
-	String profileImageUrl,
-	String nickname,
-	LocalDate createdDate,
-	LocalDate date,
-	LocalTime time,
-	Boolean limitEnable,
-	Integer memberCount,
-	Integer memberLimit,
-	Integer commentCount
+        Long cowalkId,
+        String profileImageUrl,
+        String nickname,
+        LocalDate createdDate,
+        LocalDate date,
+        LocalTime time,
+        Boolean limitEnable,
+        Integer memberCount,
+        Integer memberLimit,
+        Integer commentCount
 ) {
-	public CowalkPostDetailResponse(CowalkPost cowalkPost, Integer memberCount, Integer commentCount, Member member) {
-		this(
-			cowalkPost.getId(),
-			member.getProfileImageUrl(),
-			member.getNickname(),
-			cowalkPost.getCreatedAt().toLocalDate(),
-			cowalkPost.getDate(),
-			cowalkPost.getTime(),
-			cowalkPost.getCapacityType().equals(CapacityType.LIMITED),
-			memberCount,
-			cowalkPost.getCapacity(),
-			commentCount
-		);
-	}
+    public CowalkPostDetailResponse(CowalkPost cowalkPost, Integer memberCount, Integer commentCount, Member member) {
+        this(
+                cowalkPost.getId(),
+                member.getProfileImageUrl(),
+                member.getNickname(),
+                cowalkPost.getCreatedAt().toLocalDate(),
+                cowalkPost.getDate(),
+                cowalkPost.getTime(),
+                cowalkPost.getCapacityType().equals(CapacityType.LIMITED),
+                memberCount,
+                cowalkPost.getCapacity(),
+                commentCount
+        );
+    }
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CowalkPostDetailResponse.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CowalkPostDetailResponse.java
@@ -3,6 +3,7 @@ package com.dongsan.api.domains.cowalk.dto.response;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
+import com.dongsan.domain.domains.cowalk.domain.CapacityType;
 import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
 import com.dongsan.domain.domains.member.Member;
 
@@ -13,6 +14,7 @@ public record CowalkPostDetailResponse(
 	LocalDate createdDate,
 	LocalDate date,
 	LocalTime time,
+	Boolean limitEnable,
 	Integer memberCount,
 	Integer memberLimit,
 	Integer commentCount
@@ -25,6 +27,7 @@ public record CowalkPostDetailResponse(
 			cowalkPost.getCreatedAt().toLocalDate(),
 			cowalkPost.getDate(),
 			cowalkPost.getTime(),
+			cowalkPost.getCapacityType().equals(CapacityType.LIMITED),
 			memberCount,
 			cowalkPost.getCapacity(),
 			commentCount

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CowalkPostDetailResponse.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CowalkPostDetailResponse.java
@@ -1,0 +1,33 @@
+package com.dongsan.api.domains.cowalk.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
+import com.dongsan.domain.domains.member.Member;
+
+public record CowalkPostDetailResponse(
+	Long cowalkId,
+	String profileImageUrl,
+	String nickname,
+	LocalDate createdDate,
+	LocalDate date,
+	LocalTime time,
+	Integer memberCount,
+	Integer memberLimit,
+	Integer commentCount
+) {
+	public CowalkPostDetailResponse(CowalkPost cowalkPost, Integer memberCount, Integer commentCount, Member member) {
+		this(
+			cowalkPost.getId(),
+			member.getProfileImageUrl(),
+			member.getNickname(),
+			cowalkPost.getCreatedAt().toLocalDate(),
+			cowalkPost.getDate(),
+			cowalkPost.getTime(),
+			memberCount,
+			cowalkPost.getCapacity(),
+			commentCount
+		);
+	}
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CowalkPostsResponse.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CowalkPostsResponse.java
@@ -10,44 +10,44 @@ import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
 import com.dongsan.domain.domains.member.Member;
 
 public record CowalkPostsResponse(
-	Long cowalkId,
-	String nickname,
-	LocalDate createdDate,
-	LocalDate date,
-	LocalTime time,
-	Boolean limitEnable,
-	Integer memberCount,
-	Integer memberLimit,
-	Integer commentCount
+        Long cowalkId,
+        String nickname,
+        LocalDate createdDate,
+        LocalDate date,
+        LocalTime time,
+        Boolean limitEnable,
+        Integer memberCount,
+        Integer memberLimit,
+        Integer commentCount
 ) {
-	public CowalkPostsResponse(CowalkPost cowalkPost, Integer memberCount, Integer commentCount, Member member) {
-		this(
-			cowalkPost.getId(),
-			member.getNickname(),
-			cowalkPost.getCreatedAt().toLocalDate(),
-			cowalkPost.getDate(),
-			cowalkPost.getTime(),
-			cowalkPost.getCapacityType().equals(CapacityType.LIMITED),
-			memberCount,
-			cowalkPost.getCapacity(),
-			commentCount
-		);
-	}
+    public CowalkPostsResponse(CowalkPost cowalkPost, Integer memberCount, Integer commentCount, Member member) {
+        this(
+                cowalkPost.getId(),
+                member.getNickname(),
+                cowalkPost.getCreatedAt().toLocalDate(),
+                cowalkPost.getDate(),
+                cowalkPost.getTime(),
+                cowalkPost.getCapacityType().equals(CapacityType.LIMITED),
+                memberCount,
+                cowalkPost.getCapacity(),
+                commentCount
+        );
+    }
 
-	public static List<CowalkPostsResponse> from(
-		List<CowalkPost> cowalkPosts,
-		Map<Long, Member> memberMap,
-		Map<Long, Integer> memberCountMap,
-		Map<Long, Integer> commentCountMap
-	) {
-		return cowalkPosts.stream()
-			.map(cowalkPost -> new CowalkPostsResponse(
-					cowalkPost,
-					memberCountMap.getOrDefault(cowalkPost.getId(), 0),
-					commentCountMap.getOrDefault(cowalkPost.getId(), 0),
-					memberMap.get(cowalkPost.getMemberId())
-				)
-			)
-			.toList();
-	}
+    public static List<CowalkPostsResponse> from(
+            List<CowalkPost> cowalkPosts,
+            Map<Long, Member> memberMap,
+            Map<Long, Integer> memberCountMap,
+            Map<Long, Integer> commentCountMap
+    ) {
+        return cowalkPosts.stream()
+                .map(cowalkPost -> new CowalkPostsResponse(
+                                cowalkPost,
+                                memberCountMap.getOrDefault(cowalkPost.getId(), 0),
+                                commentCountMap.getOrDefault(cowalkPost.getId(), 0),
+                                memberMap.get(cowalkPost.getMemberId())
+                        )
+                )
+                .toList();
+    }
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CowalkPostsResponse.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CowalkPostsResponse.java
@@ -1,0 +1,50 @@
+package com.dongsan.api.domains.cowalk.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+
+import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
+import com.dongsan.domain.domains.member.Member;
+
+public record CowalkPostsResponse(
+	Long cowalkId,
+	String nickname,
+	LocalDate createdDate,
+	LocalDate date,
+	LocalTime time,
+	Integer memberCount,
+	Integer memberLimit,
+	Integer commentCount
+) {
+	public CowalkPostsResponse(CowalkPost cowalkPost, Integer memberCount, Integer commentCount, Member member) {
+		this(
+			cowalkPost.getId(),
+			member.getNickname(),
+			cowalkPost.getCreatedAt().toLocalDate(),
+			cowalkPost.getDate(),
+			cowalkPost.getTime(),
+			memberCount,
+			cowalkPost.getCapacity(),
+			commentCount
+		);
+	}
+
+	public static List<CowalkPostsResponse> from(
+		List<CowalkPost> cowalkPosts,
+		Map<Long, Member> memberMap,
+		Map<Long, Integer> memberCountMap,
+		Map<Long, Integer> commentCountMap
+	) {
+		return cowalkPosts.stream()
+			.map(cowalkPost -> new CowalkPostsResponse(
+					cowalkPost,
+					memberCountMap.getOrDefault(cowalkPost.getId(), 0),
+					commentCountMap.getOrDefault(cowalkPost.getId(), 0),
+					memberMap.get(cowalkPost.getMemberId())
+				)
+			)
+			.toList();
+	}
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CowalkPostsResponse.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CowalkPostsResponse.java
@@ -5,6 +5,7 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 
+import com.dongsan.domain.domains.cowalk.domain.CapacityType;
 import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
 import com.dongsan.domain.domains.member.Member;
 
@@ -14,6 +15,7 @@ public record CowalkPostsResponse(
 	LocalDate createdDate,
 	LocalDate date,
 	LocalTime time,
+	Boolean limitEnable,
 	Integer memberCount,
 	Integer memberLimit,
 	Integer commentCount
@@ -25,6 +27,7 @@ public record CowalkPostsResponse(
 			cowalkPost.getCreatedAt().toLocalDate(),
 			cowalkPost.getDate(),
 			cowalkPost.getTime(),
+			cowalkPost.getCapacityType().equals(CapacityType.LIMITED),
 			memberCount,
 			cowalkPost.getCapacity(),
 			commentCount

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CreateCowalkPostResponse.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CreateCowalkPostResponse.java
@@ -1,6 +1,6 @@
 package com.dongsan.api.domains.cowalk.dto.response;
 
 public record CreateCowalkPostResponse(
-	Long cowalkId
+        Long cowalkId
 ) {
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CreateCowalkPostResponse.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CreateCowalkPostResponse.java
@@ -1,0 +1,6 @@
+package com.dongsan.api.domains.cowalk.dto.response;
+
+public record CreateCowalkPostResponse(
+	Long cowalkId
+) {
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/JoinCowalkParticipantResponse.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/JoinCowalkParticipantResponse.java
@@ -1,0 +1,6 @@
+package com.dongsan.api.domains.cowalk.dto.response;
+
+public record JoinCowalkParticipantResponse(
+	Long cowalkParticipantResponse
+) {
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/JoinCowalkParticipantResponse.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/JoinCowalkParticipantResponse.java
@@ -1,6 +1,6 @@
 package com.dongsan.api.domains.cowalk.dto.response;
 
 public record JoinCowalkParticipantResponse(
-	Long cowalkParticipantResponse
+        Long cowalkParticipantResponse
 ) {
 }

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkPostFacadeTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkPostFacadeTest.java
@@ -11,7 +11,6 @@ import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import com.dongsan.api.support.IntegrationTest;
 import com.dongsan.domain.domains.auth.Provider;
@@ -30,7 +29,6 @@ import com.dongsan.domain.domains.member.Member;
 import com.dongsan.domain.domains.member.MemberCoreRepository;
 import com.dongsan.domain.domains.member.MemberRole;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class CowalkPostFacadeTest extends IntegrationTest {
 
     @Autowired
@@ -82,7 +80,7 @@ class CowalkPostFacadeTest extends IntegrationTest {
     @Test
     void 동시에_1000명이_참여하면_100명만_저장된다() throws InterruptedException {
         int executeCount = 1000;
-        ExecutorService executor = Executors.newFixedThreadPool(10);
+        ExecutorService executor = Executors.newFixedThreadPool(5);
         CountDownLatch latch = new CountDownLatch(executeCount);
 
         for (int i = 0; i < executeCount; i++) {

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkPostFacadeTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkPostFacadeTest.java
@@ -1,0 +1,89 @@
+package com.dongsan.api.domains.cowalk;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dongsan.domain.domains.cowalk.service.CowalkParticipantRdbService;
+import com.dongsan.domain.domains.cowalk.service.CowalkPostRdbService;
+import com.dongsan.domain.domains.crew.service.CrewMemberRdbService;
+
+@ExtendWith(MockitoExtension.class)
+class CowalkPostFacadeTest {
+
+	@Mock
+	private CrewMemberRdbService crewMemberRdbService;
+
+	@Mock
+	private CowalkParticipantRdbService cowalkParticipantRdbService;
+
+	@Mock
+	private CowalkPostRdbService cowalkPostRdbService;
+
+	@InjectMocks
+	private CowalkPostFacade cowalkPostFacade;
+
+	@Test
+	void 동시에_100명이_참여요청_하면_정원까지만_저장된다() throws InterruptedException {
+		// given
+		int executeCount = 100;
+		int maxParticipants = 30;
+		ExecutorService executor = Executors.newFixedThreadPool(32);
+		CountDownLatch latch = new CountDownLatch(executeCount);
+		AtomicInteger participantCounter = new AtomicInteger();
+
+		// 크루 멤버 검증은 항상 통과
+		doNothing().when(crewMemberRdbService).validateIsCrewMember(anyLong(), anyLong());
+
+		// 참가자 수: 호출될 때마다 증가하는 방식으로 mock
+		when(cowalkParticipantRdbService.countByCowalkPostId(anyLong()))
+			.thenAnswer(invocation -> participantCounter.get());
+
+		// 정원 검증: 30명 이상이면 예외 발생
+		doAnswer(invocation -> {
+			Long cowalkPostId = invocation.getArgument(0);
+			int count = invocation.getArgument(1);
+			if (count >= maxParticipants) {
+				throw new IllegalStateException("정원이 초과되었습니다.");
+			}
+			return null;
+		}).when(cowalkPostRdbService).validJoin(anyLong(), anyInt());
+
+		// save(): 성공 시에만 호출되고, 호출될 때마다 카운터 증가
+		when(cowalkParticipantRdbService.save(anyLong(), anyLong()))
+			.thenAnswer(invocation -> {
+				participantCounter.incrementAndGet();
+				return 1L;
+			});
+
+		// when
+		for (int i = 0; i < executeCount; i++) {
+			final long memberId = i + 1;
+			executor.execute(() -> {
+				try {
+					cowalkPostFacade.joinCowalkPost(1L, 1L, memberId);
+				} catch (Exception ignored) {
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+		executor.shutdown();
+
+		// then
+		assertThat(participantCounter.get()).isEqualTo(maxParticipants);
+		verify(cowalkParticipantRdbService, times(maxParticipants)).save(anyLong(), anyLong());
+	}
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkPostFacadeTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkPostFacadeTest.java
@@ -1,105 +1,105 @@
-package com.dongsan.api.domains.cowalk;
-
-import static org.assertj.core.api.AssertionsForClassTypes.*;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import com.dongsan.api.support.IntegrationTest;
-import com.dongsan.domain.domains.auth.Provider;
-import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
-import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
-import com.dongsan.domain.domains.cowalk.infrastructure.CowalkParticipantCoreRepository;
-import com.dongsan.domain.domains.cowalk.infrastructure.CowalkPostCoreRepository;
-import com.dongsan.domain.domains.crew.domain.Capacity;
-import com.dongsan.domain.domains.crew.domain.Crew;
-import com.dongsan.domain.domains.crew.domain.CrewMember;
-import com.dongsan.domain.domains.crew.domain.CrewMemberRole;
-import com.dongsan.domain.domains.crew.domain.PublicCrew;
-import com.dongsan.domain.domains.crew.infrastructure.CrewCoreRepository;
-import com.dongsan.domain.domains.crew.infrastructure.CrewMemberCoreRepository;
-import com.dongsan.domain.domains.member.Member;
-import com.dongsan.domain.domains.member.MemberCoreRepository;
-import com.dongsan.domain.domains.member.MemberRole;
-
-class CowalkPostFacadeTest extends IntegrationTest {
-
-    @Autowired
-    private CowalkPostFacade cowalkPostFacade;
-
-    @Autowired
-    private CowalkParticipantCoreRepository cowalkParticipantRepository;
-
-    @Autowired
-    private CowalkPostCoreRepository cowalkPostRepository;
-
-    @Autowired
-    private MemberCoreRepository memberRepository;
-
-    @Autowired
-    private CrewMemberCoreRepository crewMemberRepository;
-
-    @Autowired
-    private CrewCoreRepository crewRepository;
-
-    @BeforeEach
-    void setUpPost() {
-
-        Capacity capacity = new Capacity(false, 100);
-        Crew crew = new PublicCrew("name", "description", "rule", "image", capacity);
-
-        crewRepository.save(crew);
-
-        for (int i = 0; i < 1000; i++) {
-            Member member = memberRepository.save("email", "nickname", "profile", MemberRole.ROLE_USER, Provider.KAKAO);
-            crewMemberRepository.save(
-                    new CrewMember(crew.getId(), member.getId(), CrewMemberRole.PARTICIPANT)
-            );
-        }
-
-        // given
-        Integer limit = 100;
-        Long crewId = 1L;
-        Long memberId = 1L;
-
-        CreateCowalkPostCommand command
-                = new CreateCowalkPostCommand(crewId, memberId, LocalDate.now(), LocalTime.now(), limit);
-
-        // 참가 최대 인원 30인 게시글 생성
-        CowalkPost post = new CowalkPost(command);
-        cowalkPostRepository.save(post);
-    }
-
-    @Test
-    void 동시에_1000명이_참여하면_100명만_저장된다() throws InterruptedException {
-        int executeCount = 1000;
-        ExecutorService executor = Executors.newFixedThreadPool(5);
-        CountDownLatch latch = new CountDownLatch(executeCount);
-
-        for (int i = 0; i < executeCount; i++) {
-            final long memberId = i + 1;
-            executor.execute(() -> {
-                try {
-                    cowalkPostFacade.joinCowalkPost(1L, 1L, memberId);
-                } catch (Exception ignored) {
-                } finally {
-                    latch.countDown();
-                }
-            });
-        }
-
-        latch.await();
-        executor.shutdown();
-
-        // 결과 확인
-        Integer count = cowalkParticipantRepository.countByCowalkPostId(1L);
-        assertThat(count).isEqualTo(100);
-    }
-}
+// package com.dongsan.api.domains.cowalk;
+//
+// import static org.assertj.core.api.AssertionsForClassTypes.*;
+//
+// import java.time.LocalDate;
+// import java.time.LocalTime;
+// import java.util.concurrent.CountDownLatch;
+// import java.util.concurrent.ExecutorService;
+// import java.util.concurrent.Executors;
+//
+// import org.junit.jupiter.api.BeforeEach;
+// import org.junit.jupiter.api.Test;
+// import org.springframework.beans.factory.annotation.Autowired;
+//
+// import com.dongsan.api.support.IntegrationTest;
+// import com.dongsan.domain.domains.auth.Provider;
+// import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
+// import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
+// import com.dongsan.domain.domains.cowalk.infrastructure.CowalkParticipantCoreRepository;
+// import com.dongsan.domain.domains.cowalk.infrastructure.CowalkPostCoreRepository;
+// import com.dongsan.domain.domains.crew.domain.Capacity;
+// import com.dongsan.domain.domains.crew.domain.Crew;
+// import com.dongsan.domain.domains.crew.domain.CrewMember;
+// import com.dongsan.domain.domains.crew.domain.CrewMemberRole;
+// import com.dongsan.domain.domains.crew.domain.PublicCrew;
+// import com.dongsan.domain.domains.crew.infrastructure.CrewCoreRepository;
+// import com.dongsan.domain.domains.crew.infrastructure.CrewMemberCoreRepository;
+// import com.dongsan.domain.domains.member.Member;
+// import com.dongsan.domain.domains.member.MemberCoreRepository;
+// import com.dongsan.domain.domains.member.MemberRole;
+//
+// class CowalkPostFacadeTest extends IntegrationTest {
+//
+//     @Autowired
+//     private CowalkPostFacade cowalkPostFacade;
+//
+//     @Autowired
+//     private CowalkParticipantCoreRepository cowalkParticipantRepository;
+//
+//     @Autowired
+//     private CowalkPostCoreRepository cowalkPostRepository;
+//
+//     @Autowired
+//     private MemberCoreRepository memberRepository;
+//
+//     @Autowired
+//     private CrewMemberCoreRepository crewMemberRepository;
+//
+//     @Autowired
+//     private CrewCoreRepository crewRepository;
+//
+//     @BeforeEach
+//     void setUpPost() {
+//
+//         Capacity capacity = new Capacity(false, 100);
+//         Crew crew = new PublicCrew("name", "description", "rule", "image", capacity);
+//
+//         crewRepository.save(crew);
+//
+//         for (int i = 0; i < 1000; i++) {
+//             Member member = memberRepository.save("email", "nickname", "profile", MemberRole.ROLE_USER, Provider.KAKAO);
+//             crewMemberRepository.save(
+//                     new CrewMember(crew.getId(), member.getId(), CrewMemberRole.PARTICIPANT)
+//             );
+//         }
+//
+//         // given
+//         Integer limit = 100;
+//         Long crewId = 1L;
+//         Long memberId = 1L;
+//
+//         CreateCowalkPostCommand command
+//                 = new CreateCowalkPostCommand(crewId, memberId, LocalDate.now(), LocalTime.now(), limit);
+//
+//         // 참가 최대 인원 30인 게시글 생성
+//         CowalkPost post = new CowalkPost(command);
+//         cowalkPostRepository.save(post);
+//     }
+//
+//     @Test
+//     void 동시에_1000명이_참여하면_100명만_저장된다() throws InterruptedException {
+//         int executeCount = 1000;
+//         ExecutorService executor = Executors.newFixedThreadPool(32);
+//         CountDownLatch latch = new CountDownLatch(executeCount);
+//
+//         for (int i = 0; i < executeCount; i++) {
+//             final long memberId = i + 1;
+//             executor.execute(() -> {
+//                 try {
+//                     cowalkPostFacade.joinCowalkPost(1L, 1L, memberId);
+//                 } catch (Exception ignored) {
+//                 } finally {
+//                     latch.countDown();
+//                 }
+//             });
+//         }
+//
+//         latch.await();
+//         executor.shutdown();
+//
+//         // 결과 확인
+//         Integer count = cowalkParticipantRepository.countByCowalkPostId(1L);
+//         assertThat(count).isEqualTo(100);
+//     }
+// }

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkPostFacadeTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkPostFacadeTest.java
@@ -1,89 +1,107 @@
 package com.dongsan.api.domains.cowalk;
 
 import static org.assertj.core.api.AssertionsForClassTypes.*;
-import static org.mockito.Mockito.*;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
-import com.dongsan.domain.domains.cowalk.service.CowalkParticipantRdbService;
-import com.dongsan.domain.domains.cowalk.service.CowalkPostRdbService;
-import com.dongsan.domain.domains.crew.service.CrewMemberRdbService;
+import com.dongsan.api.support.IntegrationTest;
+import com.dongsan.domain.domains.auth.Provider;
+import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
+import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
+import com.dongsan.domain.domains.cowalk.infrastructure.CowalkParticipantCoreRepository;
+import com.dongsan.domain.domains.cowalk.infrastructure.CowalkPostCoreRepository;
+import com.dongsan.domain.domains.crew.domain.Capacity;
+import com.dongsan.domain.domains.crew.domain.Crew;
+import com.dongsan.domain.domains.crew.domain.CrewMember;
+import com.dongsan.domain.domains.crew.domain.CrewMemberRole;
+import com.dongsan.domain.domains.crew.domain.PublicCrew;
+import com.dongsan.domain.domains.crew.infrastructure.CrewCoreRepository;
+import com.dongsan.domain.domains.crew.infrastructure.CrewMemberCoreRepository;
+import com.dongsan.domain.domains.member.Member;
+import com.dongsan.domain.domains.member.MemberCoreRepository;
+import com.dongsan.domain.domains.member.MemberRole;
 
-@ExtendWith(MockitoExtension.class)
-class CowalkPostFacadeTest {
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class CowalkPostFacadeTest extends IntegrationTest {
 
-	@Mock
-	private CrewMemberRdbService crewMemberRdbService;
+    @Autowired
+    private CowalkPostFacade cowalkPostFacade;
 
-	@Mock
-	private CowalkParticipantRdbService cowalkParticipantRdbService;
+    @Autowired
+    private CowalkParticipantCoreRepository cowalkParticipantRepository;
 
-	@Mock
-	private CowalkPostRdbService cowalkPostRdbService;
+    @Autowired
+    private CowalkPostCoreRepository cowalkPostRepository;
 
-	@InjectMocks
-	private CowalkPostFacade cowalkPostFacade;
+    @Autowired
+    private MemberCoreRepository memberRepository;
 
-	@Test
-	void 동시에_100명이_참여요청_하면_정원까지만_저장된다() throws InterruptedException {
-		// given
-		int executeCount = 100;
-		int maxParticipants = 30;
-		ExecutorService executor = Executors.newFixedThreadPool(32);
-		CountDownLatch latch = new CountDownLatch(executeCount);
-		AtomicInteger participantCounter = new AtomicInteger();
+    @Autowired
+    private CrewMemberCoreRepository crewMemberRepository;
 
-		// 크루 멤버 검증은 항상 통과
-		doNothing().when(crewMemberRdbService).validateIsCrewMember(anyLong(), anyLong());
+    @Autowired
+    private CrewCoreRepository crewRepository;
 
-		// 참가자 수: 호출될 때마다 증가하는 방식으로 mock
-		when(cowalkParticipantRdbService.countByCowalkPostId(anyLong()))
-			.thenAnswer(invocation -> participantCounter.get());
+    @BeforeEach
+    void setUpPost() {
 
-		// 정원 검증: 30명 이상이면 예외 발생
-		doAnswer(invocation -> {
-			Long cowalkPostId = invocation.getArgument(0);
-			int count = invocation.getArgument(1);
-			if (count >= maxParticipants) {
-				throw new IllegalStateException("정원이 초과되었습니다.");
-			}
-			return null;
-		}).when(cowalkPostRdbService).validJoin(anyLong(), anyInt());
+        Capacity capacity = new Capacity(false, 100);
+        Crew crew = new PublicCrew("name", "description", "rule", "image", capacity);
 
-		// save(): 성공 시에만 호출되고, 호출될 때마다 카운터 증가
-		when(cowalkParticipantRdbService.save(anyLong(), anyLong()))
-			.thenAnswer(invocation -> {
-				participantCounter.incrementAndGet();
-				return 1L;
-			});
+        crewRepository.save(crew);
 
-		// when
-		for (int i = 0; i < executeCount; i++) {
-			final long memberId = i + 1;
-			executor.execute(() -> {
-				try {
-					cowalkPostFacade.joinCowalkPost(1L, 1L, memberId);
-				} catch (Exception ignored) {
-				} finally {
-					latch.countDown();
-				}
-			});
-		}
+        for (int i = 0; i < 1000; i++) {
+            Member member = memberRepository.save("email", "nickname", "profile", MemberRole.ROLE_USER, Provider.KAKAO);
+            crewMemberRepository.save(
+                    new CrewMember(crew.getId(), member.getId(), CrewMemberRole.PARTICIPANT)
+            );
+        }
 
-		latch.await();
-		executor.shutdown();
+        // given
+        Integer limit = 100;
+        Long crewId = 1L;
+        Long memberId = 1L;
 
-		// then
-		assertThat(participantCounter.get()).isEqualTo(maxParticipants);
-		verify(cowalkParticipantRdbService, times(maxParticipants)).save(anyLong(), anyLong());
-	}
+        CreateCowalkPostCommand command
+                = new CreateCowalkPostCommand(crewId, memberId, LocalDate.now(), LocalTime.now(), limit);
+
+        // 참가 최대 인원 30인 게시글 생성
+        CowalkPost post = new CowalkPost(command);
+        cowalkPostRepository.save(post);
+    }
+
+    @Test
+    void 동시에_100명이_참여하면_30명만_저장된다() throws InterruptedException {
+        int executeCount = 1000;
+        ExecutorService executor = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(executeCount);
+
+        for (int i = 0; i < executeCount; i++) {
+            final long memberId = i + 1;
+            executor.execute(() -> {
+                try {
+                    cowalkPostFacade.joinCowalkPost(1L, 1L, memberId);
+                } catch (Exception ignored) {
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executor.shutdown();
+
+        // 결과 확인
+        Integer count = cowalkParticipantRepository.countByCowalkPostId(1L);
+        assertThat(count).isEqualTo(100);
+    }
 }

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkPostFacadeTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkPostFacadeTest.java
@@ -80,9 +80,9 @@ class CowalkPostFacadeTest extends IntegrationTest {
     }
 
     @Test
-    void 동시에_100명이_참여하면_30명만_저장된다() throws InterruptedException {
+    void 동시에_1000명이_참여하면_100명만_저장된다() throws InterruptedException {
         int executeCount = 1000;
-        ExecutorService executor = Executors.newFixedThreadPool(32);
+        ExecutorService executor = Executors.newFixedThreadPool(10);
         CountDownLatch latch = new CountDownLatch(executeCount);
 
         for (int i = 0; i < executeCount; i++) {

--- a/dongsan-external-api/src/test/java/com/dongsan/api/support/IntegrationTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/support/IntegrationTest.java
@@ -11,6 +11,7 @@ import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.jdbc.Sql;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -36,14 +37,21 @@ public abstract class IntegrationTest {
                     .withUsername(USERNAME)
                     .withPassword(PASSWORD);
 
+    @Container
+    static GenericContainer<?> redisContainer = new GenericContainer<>("redis:7.0.11")
+            .withExposedPorts(6379);
+
     @DynamicPropertySource
     public static void overrideProps(DynamicPropertyRegistry registry) {
         // Testcontainers에서 제공하는 JDBC URL을 p6spy로 변경
-        registry.add("spring.datasource.url", () -> "jdbc:p6spy:mysql://" + mySQLContainer.getContainerIpAddress() + ":" + mySQLContainer.getMappedPort(3306) + "/" + DATABASE_NAME);
+        registry.add("spring.datasource.url", () -> "jdbc:p6spy:mysql://" + mySQLContainer.getContainerIpAddress() + ":"
+                + mySQLContainer.getMappedPort(3306) + "/" + DATABASE_NAME);
         registry.add("spring.datasource.driver-class-name", () -> "com.p6spy.engine.spy.P6SpyDriver");
         registry.add("spring.datasource.username", mySQLContainer::getUsername);
         registry.add("spring.datasource.password", mySQLContainer::getPassword);
         registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
+        registry.add("spring.data.redis.host", () -> redisContainer.getHost());
+        registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379));
     }
 
     @BeforeEach


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

## 📄 Work Description
<strong>Jira Ticket : `DB-286`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. API 개발
![image](https://github.com/user-attachments/assets/991053be-650b-4832-a5a1-893eaf93d80b)
![image](https://github.com/user-attachments/assets/1e66f7a5-7fd6-475a-9e11-44238a431d2f)
![image](https://github.com/user-attachments/assets/992e6dda-805f-425c-8570-f3bf41b826a3)
![image](https://github.com/user-attachments/assets/0b5e91ec-38a6-43e6-9894-c7332c10c41b)

#### 2. 동시성 처리
![image](https://github.com/user-attachments/assets/9d11d1aa-ed4f-495c-9802-b8774e076a5d)
일반적인 Lock을 사용하지 않은 이유는
100명 동시 요청 - 30명 처리 - 10명 추가 요청 - 남은 70명 + 추가 10명 이 Lock 경쟁
이 되는 상황이 나오게 되어서 Lock을 요청한 순서가 지켜지는 FairLock을 사용했습니다.

FairLock을 얻고 tryLock을 하는데 tryLock의 파라미터는 (대기시간, 락 자동 해제 시간, 시간 단위) 입니다.

함수형 인터페이스 Supplier를 입력받아 락이 필요한 로직을 진행하게 구현했습니다.

![image](https://github.com/user-attachments/assets/4e8ddc16-7108-465c-9f1a-464f774529e9)
Lock을 사용하는 과정에서 InterruptedException 발생하기 때문에 try - catch로 처리했습니다.

쓰레드를 강제로 중지시킬 때 interrupt를 통해 중지시키는데 InterruptedException 이 발생하고 interrupt status가 clear 됩니다. 
이렇게 되면 쓰레드가 죽지 않게 되기 때문에 sonar cloud에서 경고했던 것 같습니다. 

`Thread.currentThread().interrupt();` 로 다시 interrupt를 발생해 쓰레드를 종료하게 구현했습니다.


<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->


<br/>

## 🔗 Reference
[//]: # (문제를 해결하면서 도움이 되었거나 참고했던 사이트 또는 코드 첨부)
