### PR TITLE
[fix/DB-306]: 크루 이름 중복 API 수정

### DIFF
--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/crew/service/CrewRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/crew/service/CrewRdbService.java
@@ -1,15 +1,10 @@
 package com.dongsan.domain.domains.crew.service;
 
-import org.springframework.stereotype.Service;
-
-import com.dongsan.domain.domains.crew.domain.Capacity;
-import com.dongsan.domain.domains.crew.domain.Crew;
-import com.dongsan.domain.domains.crew.domain.CrewAccessPolicy;
-import com.dongsan.domain.domains.crew.domain.CrewInfo;
-import com.dongsan.domain.domains.crew.domain.CrewRepository;
+import com.dongsan.domain.domains.crew.domain.*;
 import com.dongsan.domain.support.error.CoreErrorCode;
 import com.dongsan.domain.support.error.CoreException;
 import com.dongsan.domain.support.paging.CursorResponse;
+import org.springframework.stereotype.Service;
 
 @Service
 public class CrewRdbService {
@@ -32,7 +27,7 @@ public class CrewRdbService {
     }
 
     public boolean isNameDuplicated(String name) {
-        return crewRepository.existsByName(name);
+        return !crewRepository.existsByName(name);
     }
 
     public Long save(CrewInfoCommand command) {


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

## 📄 Work Description
<strong>Jira Ticket : `DB-306`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. 크루 이름 중복 API 수정
- 이름이 존재하면 -> isValid = false
- 이름이 존재하지 않으면 -> isValid = true

위의 로직이 거꾸로 매핑되어서 수정했습니다.
