### PR TITLE
[fix/DB-307]: 크루 생성, 수정 이름 중복 수정

### DIFF
--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/crew/service/CrewRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/crew/service/CrewRdbService.java
@@ -1,15 +1,10 @@
 package com.dongsan.domain.domains.crew.service;
 
-import org.springframework.stereotype.Service;
-
-import com.dongsan.domain.domains.crew.domain.Capacity;
-import com.dongsan.domain.domains.crew.domain.Crew;
-import com.dongsan.domain.domains.crew.domain.CrewAccessPolicy;
-import com.dongsan.domain.domains.crew.domain.CrewInfo;
-import com.dongsan.domain.domains.crew.domain.CrewRepository;
+import com.dongsan.domain.domains.crew.domain.*;
 import com.dongsan.domain.support.error.CoreErrorCode;
 import com.dongsan.domain.support.error.CoreException;
 import com.dongsan.domain.support.paging.CursorResponse;
+import org.springframework.stereotype.Service;
 
 @Service
 public class CrewRdbService {
@@ -32,11 +27,11 @@ public class CrewRdbService {
     }
 
     public boolean isNameDuplicated(String name) {
-        return !crewRepository.existsByName(name);
+        return crewRepository.existsByName(name);
     }
 
     public Long save(CrewInfoCommand command) {
-        if (!isNameDuplicated(command.name())) {
+        if (isNameDuplicated(command.name())) {
             throw new CoreException(CoreErrorCode.CREW_NAME_DUPLICATED);
         }
 
@@ -54,7 +49,7 @@ public class CrewRdbService {
     }
 
     public void update(Crew crew, CrewInfoCommand command) {
-        if (!isNameDuplicated(command.name())) {
+        if (isNameDuplicated(command.name())) {
             throw new CoreException(CoreErrorCode.CREW_NAME_DUPLICATED);
         }
 

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/crew/service/CrewRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/crew/service/CrewRdbService.java
@@ -1,10 +1,15 @@
 package com.dongsan.domain.domains.crew.service;
 
-import com.dongsan.domain.domains.crew.domain.*;
+import org.springframework.stereotype.Service;
+
+import com.dongsan.domain.domains.crew.domain.Capacity;
+import com.dongsan.domain.domains.crew.domain.Crew;
+import com.dongsan.domain.domains.crew.domain.CrewAccessPolicy;
+import com.dongsan.domain.domains.crew.domain.CrewInfo;
+import com.dongsan.domain.domains.crew.domain.CrewRepository;
 import com.dongsan.domain.support.error.CoreErrorCode;
 import com.dongsan.domain.support.error.CoreException;
 import com.dongsan.domain.support.paging.CursorResponse;
-import org.springframework.stereotype.Service;
 
 @Service
 public class CrewRdbService {
@@ -31,7 +36,7 @@ public class CrewRdbService {
     }
 
     public Long save(CrewInfoCommand command) {
-        if (isNameDuplicated(command.name())) {
+        if (!isNameDuplicated(command.name())) {
             throw new CoreException(CoreErrorCode.CREW_NAME_DUPLICATED);
         }
 
@@ -49,7 +54,7 @@ public class CrewRdbService {
     }
 
     public void update(Crew crew, CrewInfoCommand command) {
-        if (isNameDuplicated(command.name())) {
+        if (!isNameDuplicated(command.name())) {
             throw new CoreException(CoreErrorCode.CREW_NAME_DUPLICATED);
         }
 

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/crew/CrewInfoController.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/crew/CrewInfoController.java
@@ -1,40 +1,23 @@
 package com.dongsan.api.domains.crew;
 
-import java.time.LocalDate;
-
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.dongsan.api.domains.auth.CustomAuthUser;
 import com.dongsan.api.domains.crew.dto.request.CreateUpdateCrewRequest;
 import com.dongsan.api.domains.crew.dto.request.JoinCrewRequest;
-import com.dongsan.api.domains.crew.dto.response.CreateCrewImageResponse;
-import com.dongsan.api.domains.crew.dto.response.CreateCrewResponse;
-import com.dongsan.api.domains.crew.dto.response.GetCrewFeedResponse;
-import com.dongsan.api.domains.crew.dto.response.GetCrewInfoResponse;
-import com.dongsan.api.domains.crew.dto.response.GetCrewMemberRankingResponse;
-import com.dongsan.api.domains.crew.dto.response.GetCrewsResponse;
-import com.dongsan.api.domains.crew.dto.response.IsNameDuplicatedResponse;
+import com.dongsan.api.domains.crew.dto.response.*;
 import com.dongsan.domain.support.paging.CursorRequest;
 import com.dongsan.domain.support.paging.CursorResponse;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/crews")
@@ -49,11 +32,11 @@ public class CrewInfoController {
 
     @Operation(summary = "크루 이름 중복 체크")
     @GetMapping("/exists")
-    public ResponseEntity<IsNameDuplicatedResponse> isNameDuplicated(
+    public ResponseEntity<IsNameUniqueResponse> isNameUnique(
             @RequestParam @NotBlank String name
     ) {
-        boolean isValid = crewInfoFacade.isNameDuplicated(name);
-        return ResponseEntity.ok(new IsNameDuplicatedResponse(isValid));
+        boolean isUnique = crewInfoFacade.isNameUnique(name);
+        return ResponseEntity.ok(new IsNameUniqueResponse(isUnique));
     }
 
     @Operation(summary = "크루 정보 조회")

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/crew/CrewInfoFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/crew/CrewInfoFacade.java
@@ -1,19 +1,7 @@
 package com.dongsan.api.domains.crew;
 
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Map;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.dongsan.api.domains.crew.dto.request.CreateUpdateCrewRequest;
-import com.dongsan.api.domains.crew.dto.response.CreateCrewImageResponse;
-import com.dongsan.api.domains.crew.dto.response.GetCrewFeedResponse;
-import com.dongsan.api.domains.crew.dto.response.GetCrewInfoResponse;
-import com.dongsan.api.domains.crew.dto.response.GetCrewMemberRankingResponse;
-import com.dongsan.api.domains.crew.dto.response.GetCrewsResponse;
+import com.dongsan.api.domains.crew.dto.response.*;
 import com.dongsan.api.support.util.DateRangeUtil;
 import com.dongsan.domain.domains.crew.domain.Crew;
 import com.dongsan.domain.domains.crew.domain.CrewMember;
@@ -31,6 +19,13 @@ import com.dongsan.domain.support.error.CoreException;
 import com.dongsan.domain.support.paging.CursorRequest;
 import com.dongsan.domain.support.paging.CursorResponse;
 import com.dongsan.file.service.S3FileService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @Transactional
@@ -43,8 +38,8 @@ public class CrewInfoFacade {
     private final ImageRdbService imageRdbService;
 
     public CrewInfoFacade(CrewRdbService crewRdbService, CrewMemberRdbService crewMemberRdbService,
-            WalkwayLogRdbService walkwayLogRdbService, MemberRdbService memberRdbService, S3FileService s3FileService,
-            ImageRdbService imageRdbService) {
+                          WalkwayLogRdbService walkwayLogRdbService, MemberRdbService memberRdbService, S3FileService s3FileService,
+                          ImageRdbService imageRdbService) {
         this.crewRdbService = crewRdbService;
         this.crewMemberRdbService = crewMemberRdbService;
         this.walkwayLogRdbService = walkwayLogRdbService;
@@ -54,9 +49,9 @@ public class CrewInfoFacade {
     }
 
     @Transactional(readOnly = true)
-    public boolean isNameDuplicated(String name) {
+    public boolean isNameUnique(String name) {
         name = name.trim();
-        return crewRdbService.isNameDuplicated(name);
+        return !crewRdbService.isNameDuplicated(name);
     }
 
     @Transactional
@@ -117,7 +112,7 @@ public class CrewInfoFacade {
 
     @Transactional(readOnly = true)
     public CursorResponse<GetCrewMemberRankingResponse> getCrewMemberRanking(Long crewId, Long memberId, LocalDate date,
-            CrewRankingSort sort, CrewRankingPeriod period, CursorRequest paging) {
+                                                                             CrewRankingSort sort, CrewRankingPeriod period, CursorRequest paging) {
         Crew crew = crewRdbService.getCrew(crewId);
         boolean isCrewMember = crewMemberRdbService.isCrewMember(crewId, memberId);
         crew.canAccess(isCrewMember);

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/crew/dto/response/IsNameUniqueResponse.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/crew/dto/response/IsNameUniqueResponse.java
@@ -1,6 +1,6 @@
 package com.dongsan.api.domains.crew.dto.response;
 
-public record IsNameDuplicatedResponse(
+public record IsNameUniqueResponse(
         boolean isValid
 ) {
 }


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

## 📄 Work Description
<strong>Jira Ticket : `DB-307`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. 크루 생성, 수정 이름 중복 수정
![image](https://github.com/user-attachments/assets/6a7ce4ff-5077-41f7-b862-5a664584859a)
중복 확인 로직이 반대로 바뀌어서 수정

<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->


<br/>

## 🔗 Reference
[//]: # (문제를 해결하면서 도움이 되었거나 참고했던 사이트 또는 코드 첨부)
