### PR TITLE
[feature/DB-323]: external-api & socket 모듈 통합, 같이 산책하기 관련 API 추가&수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,8 +40,6 @@ jobs:
         run: |
           docker build -t ${{secrets.DOCKER_REPO}}:api -f dongsan-external-api/Dockerfile .
           docker push ${{secrets.DOCKER_REPO}}:api
-          docker build -t ${{secrets.DOCKER_REPO}}:socket -f dongsan-socket/Dockerfile .
-          docker push ${{secrets.DOCKER_REPO}}:socket
 
       - name: Deploy to dev
         uses: appleboy/ssh-action@master
@@ -52,12 +50,11 @@ jobs:
           port: 22
           script: |
             sudo docker login -u ${{secrets.DOCKER_HUB_USERNAME}} -p ${{secrets.DOCKER_HUB_PASSWORD}}
-            sudo docker ps -qa --filter "name=dongsan-api" --filter "name=dongsan-websocket" | xargs -r sudo docker rm -f
+            sudo docker rm -f $(sudo docker ps -aq)
             sudo docker pull ${{secrets.DOCKER_REPO}}:api
-            sudo docker pull ${{secrets.DOCKER_REPO}}:socket
             cd /home/ubuntu/deploy
-            sudo docker-compose pull
-            sudo docker-compose up -d
+            sudo docker compose pull
+            sudo docker compose up -d
             sudo docker image prune -f
 
       - name: Report to CodeCov

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/CreateCowalkPostCommand.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/CreateCowalkPostCommand.java
@@ -8,6 +8,7 @@ public record CreateCowalkPostCommand(
         Long memberId,
         LocalDate date,
         LocalTime time,
-        Integer capacity
+        Integer capacity,
+        String memo
 ) {
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
@@ -29,6 +29,8 @@ public class CowalkPost extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private CapacityType capacityType;
 
+    private String memo;
+
     protected CowalkPost() {
     }
 
@@ -38,6 +40,7 @@ public class CowalkPost extends BaseEntity {
         this.startedAt = LocalDateTime.of(command.date(), command.time());
         this.capacity = command.capacity();
         this.capacityType = command.capacity() == null ? CapacityType.UNLIMITED : CapacityType.LIMITED;
+        this.memo = command.memo();
     }
 
     public void validCapacity(Integer participantCount) {
@@ -75,5 +78,9 @@ public class CowalkPost extends BaseEntity {
 
     public CapacityType getCapacityType() {
         return capacityType;
+    }
+
+    public String getMemo() {
+        return memo;
     }
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
@@ -65,6 +65,10 @@ public class CowalkPost extends BaseEntity {
         return startedAt.toLocalTime();
     }
 
+    public LocalDateTime getStartedAt() {
+        return startedAt;
+    }
+
     public Integer getCapacity() {
         return capacity;
     }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
@@ -1,21 +1,15 @@
 package com.dongsan.domain.domains.cowalk.domain;
 
-import static com.dongsan.domain.support.error.CoreErrorCode.*;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
-
 import com.dongsan.domain.domains.common.BaseEntity;
 import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
 import com.dongsan.domain.support.error.CoreException;
+import jakarta.persistence.*;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static com.dongsan.domain.support.error.CoreErrorCode.COWALK_PARTICIPANT_LIMIT;
 
 @Entity
 @Table(name = "cowalk_post")
@@ -28,9 +22,7 @@ public class CowalkPost extends BaseEntity {
 
     private Long memberId;
 
-    private LocalDate date;
-
-    private LocalTime time;
+    private LocalDateTime startedAt;
 
     private Integer capacity;
 
@@ -43,8 +35,7 @@ public class CowalkPost extends BaseEntity {
     public CowalkPost(CreateCowalkPostCommand command) {
         this.crewId = command.crewId();
         this.memberId = command.memberId();
-        this.date = command.date();
-        this.time = command.time();
+        this.startedAt = LocalDateTime.of(command.date(), command.time());
         this.capacity = command.capacity();
         this.capacityType = command.capacity() == null ? CapacityType.UNLIMITED : CapacityType.LIMITED;
     }
@@ -67,11 +58,11 @@ public class CowalkPost extends BaseEntity {
     }
 
     public LocalDate getDate() {
-        return date;
+        return startedAt.toLocalDate();
     }
 
     public LocalTime getTime() {
-        return time;
+        return startedAt.toLocalTime();
     }
 
     public Integer getCapacity() {

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPostRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPostRepository.java
@@ -3,6 +3,7 @@ package com.dongsan.domain.domains.cowalk.domain;
 import com.dongsan.domain.support.paging.CursorResponse;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
@@ -12,4 +13,6 @@ public interface CowalkPostRepository {
     Optional<CowalkPost> findById(Long id);
 
     CursorResponse<CowalkPost> getCowalkPosts(Integer size, Long lastId, Long crewId);
+
+    CursorResponse<CowalkPost> getJoinedCowalkPost(Long memberId, LocalDateTime twentyFourHoursAgo, Long lastId, int size);
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkPostCoreRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkPostCoreRepository.java
@@ -2,12 +2,14 @@ package com.dongsan.domain.domains.cowalk.infrastructure;
 
 import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
 import com.dongsan.domain.domains.cowalk.domain.CowalkPostRepository;
+import com.dongsan.domain.domains.cowalk.domain.QCowalkParticipant;
 import com.dongsan.domain.domains.cowalk.domain.QCowalkPost;
 import com.dongsan.domain.support.paging.CursorResponse;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,6 +20,7 @@ public class CowalkPostCoreRepository implements CowalkPostRepository {
     private final JPAQueryFactory queryFactory;
 
     private final QCowalkPost cowalkPost = QCowalkPost.cowalkPost;
+    private final QCowalkParticipant cowalkParticipant = QCowalkParticipant.cowalkParticipant;
 
     public CowalkPostCoreRepository(CowalkPostJpaRepository cowalkPostJpaRepository, JPAQueryFactory queryFactory) {
         this.cowalkPostJpaRepository = cowalkPostJpaRepository;
@@ -50,5 +53,40 @@ public class CowalkPostCoreRepository implements CowalkPostRepository {
 
     private BooleanExpression cowalkPostIdLt(Long id) {
         return id == null ? null : cowalkPost.id.lt(id);
+    }
+
+    @Override
+    public CursorResponse<CowalkPost> getJoinedCowalkPost(Long memberId, LocalDateTime twentyFourHoursAgo, Long lastId, int size) {
+        CowalkPost lastCowalkPost = this.getCowalkPostEntity(lastId);
+
+        List<CowalkPost> cowalkPosts = queryFactory.selectFrom(cowalkPost)
+                .join(cowalkParticipant).on(cowalkPost.id.eq(cowalkParticipant.cowalkPostId))
+                .where(cowalkParticipant.memberId.eq(memberId),
+                        cowalkPost.startedAt.gt(twentyFourHoursAgo),
+                        cowalkPostStartedAtLt(lastCowalkPost)
+                )
+                .orderBy(cowalkPost.startedAt.asc(), cowalkPost.id.asc())
+                .limit(size + 1L)
+                .fetch();
+
+        return new CursorResponse<>(cowalkPosts, size);
+    }
+
+    private BooleanExpression cowalkPostStartedAtLt(CowalkPost lastCowalkPost) {
+        if (lastCowalkPost == null) {
+            return null;
+        }
+        return cowalkPost.startedAt.gt(lastCowalkPost.getStartedAt())
+                .or(cowalkPost.startedAt.eq(lastCowalkPost.getStartedAt()).and(cowalkPost.id.gt(lastCowalkPost.getId())));
+    }
+
+    // 마지막 산책로 엔티티 조회
+    private CowalkPost getCowalkPostEntity(Long cowalkId) {
+        if (cowalkId == null) {
+            return null;
+        }
+        return queryFactory.selectFrom(cowalkPost)
+                .where(cowalkPost.id.eq(cowalkId))
+                .fetchOne();
     }
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkPostRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkPostRdbService.java
@@ -8,6 +8,8 @@ import com.dongsan.domain.support.paging.CursorResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 import static com.dongsan.domain.support.error.CoreErrorCode.COWALK_NOT_FOUND;
 
 @Service
@@ -37,5 +39,10 @@ public class CowalkPostRdbService {
     public void validCapacity(Long cowalkPostId, Integer participantCount) {
         CowalkPost cowalkPost = getCowalkPost(cowalkPostId);
         cowalkPost.validCapacity(participantCount);
+    }
+
+    public CursorResponse<CowalkPost> getJoinedCowalkPost(Long memberId, Long lastId, int size) {
+        LocalDateTime twentyFourHoursAgo = LocalDateTime.now().minusHours(24);
+        return cowalkPostRepository.getJoinedCowalkPost(memberId, twentyFourHoursAgo, lastId, size);
     }
 }

--- a/dongsan-core/domain-rdb/src/test/java/com/dongsan/domain/domains/cowalk/domain/CowalkPostTest.java
+++ b/dongsan-core/domain-rdb/src/test/java/com/dongsan/domain/domains/cowalk/domain/CowalkPostTest.java
@@ -1,35 +1,35 @@
 package com.dongsan.domain.domains.cowalk.domain;
 
-import static org.assertj.core.api.Assertions.*;
+import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
+import com.dongsan.domain.support.error.CoreException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
-import com.dongsan.domain.support.error.CoreException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CowalkPostTest {
 
-	@Test
-	@DisplayName("participantCount(참가인원)이 capacity 이상이면 예외가 발생한다")
-	void Throw_Exception_Capacity_Limit() {
-		// given
-		Integer participantCount = 5;
-		Integer capacity = 5;
-		Long crewId = 1L;
-		Long memberId = 1L;
+    @Test
+    @DisplayName("participantCount(참가인원)이 capacity 이상이면 예외가 발생한다")
+    void Throw_Exception_Capacity_Limit() {
+        // given
+        Integer participantCount = 5;
+        Integer capacity = 5;
+        Long crewId = 1L;
+        Long memberId = 1L;
+        String memo = "memo";
 
-		CreateCowalkPostCommand command
-			= new CreateCowalkPostCommand(crewId, memberId, LocalDate.now(), LocalTime.now(), capacity);
+        CreateCowalkPostCommand command
+                = new CreateCowalkPostCommand(crewId, memberId, LocalDate.now(), LocalTime.now(), capacity, memo);
 
-		CowalkPost cowalkPost = new CowalkPost(command);
+        CowalkPost cowalkPost = new CowalkPost(command);
 
-		// when & then
-		assertThatThrownBy(() -> cowalkPost.validCapacity(participantCount))
-			.isInstanceOf(CoreException.class);
-	}
+        // when & then
+        assertThatThrownBy(() -> cowalkPost.validCapacity(participantCount))
+                .isInstanceOf(CoreException.class);
+    }
 
 }

--- a/dongsan-external-api/build.gradle
+++ b/dongsan-external-api/build.gradle
@@ -35,6 +35,10 @@ dependencies {
 
     // test 시 patch 가능하게
     testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.2'
+
+    // socket 모듈 이전 시 삭제
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework:spring-messaging'
 }
 
 // application.yml 설정 파일 복사

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostController.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostController.java
@@ -1,30 +1,17 @@
 package com.dongsan.api.domains.cowalk;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.dongsan.api.domains.auth.CustomAuthUser;
 import com.dongsan.api.domains.cowalk.dto.request.CreateCowalkCommentRequest;
 import com.dongsan.api.domains.cowalk.dto.request.CreateCowalkPostRequest;
-import com.dongsan.api.domains.cowalk.dto.response.CowalkCommentResponse;
-import com.dongsan.api.domains.cowalk.dto.response.CowalkPostDetailResponse;
-import com.dongsan.api.domains.cowalk.dto.response.CowalkPostsResponse;
-import com.dongsan.api.domains.cowalk.dto.response.CreateCowalkCommentResponse;
-import com.dongsan.api.domains.cowalk.dto.response.CreateCowalkPostResponse;
-import com.dongsan.api.domains.cowalk.dto.response.JoinCowalkParticipantResponse;
+import com.dongsan.api.domains.cowalk.dto.response.*;
 import com.dongsan.domain.support.paging.CursorResponse;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/crews")

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/MyCowalkController.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/MyCowalkController.java
@@ -1,0 +1,40 @@
+package com.dongsan.api.domains.cowalk;
+
+import com.dongsan.api.domains.auth.CustomAuthUser;
+import com.dongsan.api.domains.cowalk.dto.response.GetMyCowalkResponse;
+import com.dongsan.domain.support.paging.CursorRequest;
+import com.dongsan.domain.support.paging.CursorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users/cowalk")
+@Validated
+@Tag(name = "마이페이지")
+public class MyCowalkController {
+
+    private final MyCowalkFacade myCowalkFacade;
+
+    public MyCowalkController(MyCowalkFacade myCowalkFacade) {
+        this.myCowalkFacade = myCowalkFacade;
+    }
+
+    @Operation(summary = "내가 신청한 같이 산책하기 목록 조회")
+    @GetMapping()
+    public ResponseEntity<CursorResponse<GetMyCowalkResponse>> getMyCowalk(
+            @RequestParam(required = false) Long lastId,
+            @RequestParam(defaultValue = "3") Integer size,
+            @AuthenticationPrincipal CustomAuthUser customAuthUser
+    ) {
+        CursorRequest cursorRequest = new CursorRequest(lastId, size);
+        CursorResponse<GetMyCowalkResponse> response = myCowalkFacade.getMyCowalk(cursorRequest, customAuthUser.getMemberId());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/MyCowalkFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/MyCowalkFacade.java
@@ -1,0 +1,22 @@
+package com.dongsan.api.domains.cowalk;
+
+import com.dongsan.api.domains.cowalk.dto.response.GetMyCowalkResponse;
+import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
+import com.dongsan.domain.domains.cowalk.service.CowalkPostRdbService;
+import com.dongsan.domain.support.paging.CursorRequest;
+import com.dongsan.domain.support.paging.CursorResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MyCowalkFacade {
+    private final CowalkPostRdbService cowalkPostRdbService;
+
+    public MyCowalkFacade(CowalkPostRdbService cowalkPostRdbService) {
+        this.cowalkPostRdbService = cowalkPostRdbService;
+    }
+
+    public CursorResponse<GetMyCowalkResponse> getMyCowalk(CursorRequest cursorRequest, Long memberId) {
+        CursorResponse<CowalkPost> result = cowalkPostRdbService.getJoinedCowalkPost(memberId, cursorRequest.lastId(), cursorRequest.size());
+        return new CursorResponse<>(GetMyCowalkResponse.from(result.getData()), result.getHasNext());
+    }
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/request/CreateCowalkPostRequest.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/request/CreateCowalkPostRequest.java
@@ -1,14 +1,13 @@
 package com.dongsan.api.domains.cowalk.dto.request;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-
-import org.hibernate.validator.constraints.Range;
-
 import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.Range;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 public record CreateCowalkPostRequest(
         @NotNull(message = "산책 날짜를 입력해주세요")
@@ -22,7 +21,10 @@ public record CreateCowalkPostRequest(
         Boolean limitEnable,
 
         @Range(min = 2, max = 100, message = "인원은 2~100명까지 가능합니다")
-        Integer memberLimit
+        Integer memberLimit,
+
+        @Size(max = 200, message = "메모는 200자를 넘길 수 없습니다.")
+        String memo
 ) {
     public CreateCowalkPostCommand toCreateCowalkPostCommand(Long crewId, Long memberId) {
         return new CreateCowalkPostCommand(
@@ -30,7 +32,8 @@ public record CreateCowalkPostRequest(
                 memberId,
                 date,
                 time,
-                memberLimit
+                memberLimit,
+                memo
         );
     }
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CowalkPostDetailResponse.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CowalkPostDetailResponse.java
@@ -1,11 +1,11 @@
 package com.dongsan.api.domains.cowalk.dto.response;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-
 import com.dongsan.domain.domains.cowalk.domain.CapacityType;
 import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
 import com.dongsan.domain.domains.member.Member;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 public record CowalkPostDetailResponse(
         Long cowalkId,
@@ -17,7 +17,8 @@ public record CowalkPostDetailResponse(
         Boolean limitEnable,
         Integer memberCount,
         Integer memberLimit,
-        Integer commentCount
+        Integer commentCount,
+        String memo
 ) {
     public CowalkPostDetailResponse(CowalkPost cowalkPost, Integer memberCount, Integer commentCount, Member member) {
         this(
@@ -30,7 +31,8 @@ public record CowalkPostDetailResponse(
                 cowalkPost.getCapacityType().equals(CapacityType.LIMITED),
                 memberCount,
                 cowalkPost.getCapacity(),
-                commentCount
+                commentCount,
+                cowalkPost.getMemo()
         );
     }
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CowalkPostsResponse.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/CowalkPostsResponse.java
@@ -1,13 +1,13 @@
 package com.dongsan.api.domains.cowalk.dto.response;
 
+import com.dongsan.domain.domains.cowalk.domain.CapacityType;
+import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
+import com.dongsan.domain.domains.member.Member;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
-
-import com.dongsan.domain.domains.cowalk.domain.CapacityType;
-import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
-import com.dongsan.domain.domains.member.Member;
 
 public record CowalkPostsResponse(
         Long cowalkId,
@@ -18,7 +18,8 @@ public record CowalkPostsResponse(
         Boolean limitEnable,
         Integer memberCount,
         Integer memberLimit,
-        Integer commentCount
+        Integer commentCount,
+        String memo
 ) {
     public CowalkPostsResponse(CowalkPost cowalkPost, Integer memberCount, Integer commentCount, Member member) {
         this(
@@ -30,7 +31,8 @@ public record CowalkPostsResponse(
                 cowalkPost.getCapacityType().equals(CapacityType.LIMITED),
                 memberCount,
                 cowalkPost.getCapacity(),
-                commentCount
+                commentCount,
+                cowalkPost.getMemo()
         );
     }
 

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/GetMyCowalkResponse.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/GetMyCowalkResponse.java
@@ -1,0 +1,19 @@
+package com.dongsan.api.domains.cowalk.dto.response;
+
+import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public record GetMyCowalkResponse(
+        Long cowalkId,
+        LocalDate date,
+        LocalTime time
+) {
+    public static List<GetMyCowalkResponse> from(List<CowalkPost> cowalkPostList) {
+        return cowalkPostList.stream()
+                .map(c -> new GetMyCowalkResponse(c.getId(), c.getDate(), c.getTime()))
+                .toList();
+    }
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/socket/CountResponse.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/socket/CountResponse.java
@@ -1,0 +1,6 @@
+package com.dongsan.socket;
+
+public record CountResponse(
+        int count
+) {
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/socket/EndWalkRequest.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/socket/EndWalkRequest.java
@@ -1,0 +1,8 @@
+package com.dongsan.socket;
+
+import java.util.List;
+
+public record EndWalkRequest(
+        List<Long> crewIds
+) {
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/socket/OngoingWalkRequest.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/socket/OngoingWalkRequest.java
@@ -1,0 +1,10 @@
+package com.dongsan.socket;
+
+import java.util.List;
+
+public record OngoingWalkRequest(
+        List<Long> crewIds,
+        long distanceMeter,
+        long timeMin
+) {
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/socket/WalkController.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/socket/WalkController.java
@@ -1,0 +1,93 @@
+package com.dongsan.socket;
+
+import com.dongsan.domain.domains.cowalk.CowalkCacheRepository;
+import com.dongsan.domain.domains.crew.CrewWalkCacheRepository;
+import com.dongsan.domain.domains.crew.WalkData;
+import com.dongsan.socket.authenticate.SocketUserPrincipal;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+import java.util.List;
+
+@Controller
+public class WalkController {
+
+    private final SimpMessagingTemplate simpMessagingTemplate;
+    private final CrewWalkCacheRepository crewWalkCacheRepository;
+    private final CowalkCacheRepository cowalkCacheRepository;
+
+    public WalkController(SimpMessagingTemplate simpMessagingTemplate, CrewWalkCacheRepository crewWalkCacheRepository, CowalkCacheRepository cowalkCacheRepository) {
+        this.simpMessagingTemplate = simpMessagingTemplate;
+        this.crewWalkCacheRepository = crewWalkCacheRepository;
+        this.cowalkCacheRepository = cowalkCacheRepository;
+    }
+
+    private static String getCrewCountDestination(Long crewId) {
+        return "/topic/walk/crew/" + crewId + "/count";
+    }
+
+    private static String getCrewDetailDestination(Long crewId) {
+        return "/topic/walk/crew/" + crewId + "/detail";
+    }
+
+    private static String getCowalkCountDestination(Long cowalkId) {
+        return "/topic/walk/cowalk/" + cowalkId + "/count";
+    }
+
+    @MessageMapping("/walk/ongoing")
+    public void ongoingWalk(
+            @Payload OngoingWalkRequest payload,
+            Principal principal
+    ) {
+        SocketUserPrincipal user = (SocketUserPrincipal) principal;
+
+        for (Long crewId : payload.crewIds()) {
+            crewWalkCacheRepository.saveCrewMemberWalk(crewId, user.getMemberId(), user.getNickname(),
+                    payload.distanceMeter(), payload.timeMin());
+            List<WalkData> walkDataList = crewWalkCacheRepository.getAllCrewMemberWalk(crewId);
+            simpMessagingTemplate.convertAndSend(getCrewCountDestination(crewId), new CountResponse(walkDataList.size()));
+            simpMessagingTemplate.convertAndSend(getCrewDetailDestination(crewId), walkDataList);
+        }
+    }
+
+    @MessageMapping("/walk/end")
+    public void endWalk(
+            @Payload EndWalkRequest payload,
+            Principal principal
+    ) {
+        SocketUserPrincipal user = (SocketUserPrincipal) principal;
+
+        for (Long crewId : payload.crewIds()) {
+            crewWalkCacheRepository.deleteCrewMemberWalk(crewId, user.getMemberId());
+            List<WalkData> walkDataList = crewWalkCacheRepository.getAllCrewMemberWalk(crewId);
+            simpMessagingTemplate.convertAndSend(getCrewCountDestination(crewId), new CountResponse(walkDataList.size()));
+            simpMessagingTemplate.convertAndSend(getCrewDetailDestination(crewId), walkDataList);
+        }
+    }
+
+    @MessageMapping("/walk/cowalk/{cowalkId}/ongoing")
+    public void ongoingCowalk(
+            @DestinationVariable("cowalkId") Long cowalkId,
+            Principal principal
+    ) {
+        SocketUserPrincipal user = (SocketUserPrincipal) principal;
+        cowalkCacheRepository.saveCowalker(cowalkId, user.getMemberId());
+        int count = cowalkCacheRepository.countCowalker(cowalkId);
+        simpMessagingTemplate.convertAndSend(getCowalkCountDestination(cowalkId), new CountResponse(count));
+    }
+
+    @MessageMapping("/walk/cowalk/{cowalkId}/end")
+    public void endCowalk(
+            @DestinationVariable("cowalkId") Long cowalkId,
+            Principal principal
+    ) {
+        SocketUserPrincipal user = (SocketUserPrincipal) principal;
+        cowalkCacheRepository.deleteCowalker(cowalkId, user.getMemberId());
+        int count = cowalkCacheRepository.countCowalker(cowalkId);
+        simpMessagingTemplate.convertAndSend(getCowalkCountDestination(cowalkId), new CountResponse(count));
+    }
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/socket/WebSocketConfig.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/socket/WebSocketConfig.java
@@ -1,0 +1,49 @@
+package com.dongsan.socket;
+
+import com.dongsan.socket.authenticate.SocketCookieService;
+import com.dongsan.socket.authenticate.SocketJwtService;
+import com.dongsan.socket.authenticate.WebSocketHandshakeHandler;
+import com.dongsan.socket.authenticate.WebSocketHandshakeInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final SocketJwtService socketJwtService;
+    private final SocketCookieService socketCookieService;
+
+    public WebSocketConfig(SocketJwtService socketJwtService, SocketCookieService socketCookieService) {
+        this.socketJwtService = socketJwtService;
+        this.socketCookieService = socketCookieService;
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns(
+                        "http://localhost:8080",
+                        "http://localhost:3000",
+                        "http://dongsanwalk.site",
+                        "http://api.dongsanwalk.site:8080",
+                        "https://dongsanwalk.site",
+                        "https://www.dongsanwalk.site",
+                        "https://api.dongsanwalk.site",
+                        "http://front.dongsanwalk.site:3000"
+                )
+                .addInterceptors(new WebSocketHandshakeInterceptor(socketCookieService, socketJwtService))
+                .setHandshakeHandler(new WebSocketHandshakeHandler())
+                .withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/socket/authenticate/SocketCookieService.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/socket/authenticate/SocketCookieService.java
@@ -1,0 +1,24 @@
+package com.dongsan.socket.authenticate;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SocketCookieService {
+
+    private static final String ACCESS_TOKEN = "accessToken";
+
+    public String getAccessTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if (cookie.getName()
+                        .equals(SocketCookieService.ACCESS_TOKEN)) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/socket/authenticate/SocketJwtService.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/socket/authenticate/SocketJwtService.java
@@ -1,0 +1,79 @@
+package com.dongsan.socket.authenticate;
+
+import com.dongsan.domain.domains.member.Member;
+import com.dongsan.domain.domains.member.MemberRdbService;
+import com.dongsan.domain.support.error.CoreErrorCode;
+import com.dongsan.domain.support.error.CoreException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Service
+public class SocketJwtService {
+
+    private static final Logger log = LoggerFactory.getLogger(SocketJwtService.class);
+
+    private final MemberRdbService memberRdbService;
+
+    @Value("${jwt.access.secret}")
+    private String accessTokenSecret;
+    private SecretKey accessTokenSecretKey;
+
+    public SocketJwtService(MemberRdbService memberRdbService) {
+        this.memberRdbService = memberRdbService;
+    }
+
+    @PostConstruct
+    public void initialize() {
+        accessTokenSecretKey = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(accessTokenSecret));
+    }
+
+    public boolean isAccessTokenExpired(String accessToken) {
+        if (accessToken == null)
+            return true;
+        long remainingTime = getRemainingTimeMillis(accessToken, accessTokenSecretKey);
+        return remainingTime == 0;
+    }
+
+    private long getRemainingTimeMillis(String token, SecretKey secretKey) {
+        try {
+            Date expiration = extractAll(token, secretKey).getExpiration();
+            long remainingTime = expiration.getTime() - System.currentTimeMillis();
+            return Math.max(remainingTime, 0);
+        } catch (JwtException e) {
+            if (e instanceof ExpiredJwtException) {
+                log.info("[AUTH_INFO] JWT 토큰이 만료: {}", e.getMessage());
+            } else {
+                log.error("[AUTH_ERROR] JWT 토큰 만료 검사중 알 수 없는 오류 발생: {}", e.getMessage());
+            }
+            return 0;
+        }
+    }
+
+    public Member getMemberFromAccessToken(String accessToken) {
+        Long memberId = extractAll(accessToken, accessTokenSecretKey)
+                .get("memberId", Long.class);
+        log.info("websocket 인증 사용자 ID : {}", memberId);
+        return memberRdbService.getOptionalMember(memberId)
+                .orElseThrow(() -> new CoreException(CoreErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private Claims extractAll(String token, SecretKey secretKey) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/socket/authenticate/SocketUserPrincipal.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/socket/authenticate/SocketUserPrincipal.java
@@ -1,0 +1,28 @@
+package com.dongsan.socket.authenticate;
+
+import com.dongsan.domain.domains.member.Member;
+
+import java.security.Principal;
+
+public class SocketUserPrincipal implements Principal {
+    private final Long memberId;
+    private final String nickname;
+
+    public SocketUserPrincipal(Member member) {
+        this.memberId = member.getId();
+        this.nickname = member.getNickname();
+    }
+
+    @Override
+    public String getName() {
+        return memberId.toString();
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/socket/authenticate/WebSocketHandshakeHandler.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/socket/authenticate/WebSocketHandshakeHandler.java
@@ -1,0 +1,17 @@
+package com.dongsan.socket.authenticate;
+
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+
+import java.security.Principal;
+import java.util.Map;
+
+public class WebSocketHandshakeHandler extends DefaultHandshakeHandler {
+    @Override
+    protected Principal determineUser(ServerHttpRequest request,
+                                      WebSocketHandler wsHandler,
+                                      Map<String, Object> attributes) {
+        return (SocketUserPrincipal) attributes.get("user");  // 여기서 user null 처리
+    }
+}

--- a/dongsan-external-api/src/main/java/com/dongsan/socket/authenticate/WebSocketHandshakeInterceptor.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/socket/authenticate/WebSocketHandshakeInterceptor.java
@@ -1,0 +1,62 @@
+package com.dongsan.socket.authenticate;
+
+import com.dongsan.domain.domains.member.Member;
+import com.dongsan.domain.support.error.CoreException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+public class WebSocketHandshakeInterceptor implements HandshakeInterceptor {
+    private static final Logger log = LoggerFactory.getLogger(WebSocketHandshakeInterceptor.class);
+    private final SocketCookieService socketCookieService;
+    private final SocketJwtService socketJwtService;
+
+    public WebSocketHandshakeInterceptor(SocketCookieService socketCookieService, SocketJwtService socketJwtService) {
+        this.socketCookieService = socketCookieService;
+        this.socketJwtService = socketJwtService;
+    }
+
+    // WebSocket 연결 시점의 핸드쉐이크 과정에서 호출되는데, 이 단계에서는 클라이언트와 아직 연결이 완료된 상태가 아니고, 메시지를 주고받을 수 있는 상태가 아님
+    // 예외를 잡아서 로그를 남기고, false를 반환해 연결을 차단하는 방식으로 처리
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request,
+                                   ServerHttpResponse response,
+                                   WebSocketHandler wsHandler,
+                                   Map<String, Object> attributes) throws Exception {
+        if (!(request instanceof ServletServerHttpRequest servletRequest)) return false;
+
+        HttpServletRequest httpServletRequest = servletRequest.getServletRequest();
+        try {
+            String accessToken = socketCookieService.getAccessTokenFromCookie(httpServletRequest);
+            if (!socketJwtService.isAccessTokenExpired(accessToken)) {
+                Member member = socketJwtService.getMemberFromAccessToken(accessToken);
+                SocketUserPrincipal user = new SocketUserPrincipal(member);
+                attributes.put("user", user);  // 세션에 넣기
+                return true;
+            }
+        } catch (CoreException e) {
+            log.warn("websocket 인증 실패 : {}", e.getMessage());
+            response.setStatusCode(HttpStatus.UNAUTHORIZED);
+            return false;
+        } catch (Exception e) {
+            return false;
+        }
+        return false;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request,
+                               ServerHttpResponse response,
+                               WebSocketHandler wsHandler,
+                               Exception exception) {
+        // nothing
+    }
+}


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

## 📄 Work Description
<strong>Jira Ticket : `DB-323`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1.  external-api & socket 모듈 통합
모듈을 분리하여 각각 컨테이너화 하여 배포했을 때 서버 터짐 이슈가 있어서, 우선 빠른 소켓 연동을 위해 하나의 모듈로 통합했습니다.

#### 2. 내가 신청한 같이 산책하기 조회 API 개발
현재 시간 기준 같이 산책하기의 startedAt이 하루 전인것 부터 조회 가능합니다. 
paging의 default size = 3 입니다.
<img width="1006" alt="스크린샷 2025-06-26 오후 1 57 46" src="https://github.com/user-attachments/assets/07140883-c6d7-48d1-b488-9ad3b0b879ac" />


#### 3. 같이 산책하기 등록 시 memo 필드 추가
같이 산책하기 상세 조회 시에도 memo 필드 반환하도록 수정했습니다.


<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->


<br/>

## 🔗 Reference
[//]: # (문제를 해결하면서 도움이 되었거나 참고했던 사이트 또는 코드 첨부)
