### PR TITLE
[feature/DB-377]: 같이 산책하기 - 종료 시간 추가

### DIFF
--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/CreateCowalkPostCommand.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/CreateCowalkPostCommand.java
@@ -1,14 +1,14 @@
 package com.dongsan.domain.domains.cowalk;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 
 public record CreateCowalkPostCommand(
         Long crewId,
         Long memberId,
-        LocalDate date,
-        LocalTime time,
+        LocalDateTime startedAt,
+        LocalDateTime endedAt,
         Integer capacity,
         String memo
 ) {
+
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPost.java
@@ -2,18 +2,22 @@ package com.dongsan.domain.domains.cowalk.domain;
 
 import com.dongsan.domain.domains.common.BaseEntity;
 import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
+import com.dongsan.domain.support.error.CoreErrorCode;
 import com.dongsan.domain.support.error.CoreException;
 import jakarta.persistence.*;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
-import static com.dongsan.domain.support.error.CoreErrorCode.COWALK_PARTICIPANT_LIMIT;
 
 @Entity
 @Table(name = "cowalk_post")
 public class CowalkPost extends BaseEntity {
+    private static final long MIN_DURATION_HOUR = 1;
+    private static final long MAX_DURATION_HOUR = 3;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -22,7 +26,11 @@ public class CowalkPost extends BaseEntity {
 
     private Long memberId;
 
+    @Column(nullable = false)
     private LocalDateTime startedAt;
+
+    @Column(nullable = false)
+    private LocalDateTime endedAt;
 
     private Integer capacity;
 
@@ -37,7 +45,8 @@ public class CowalkPost extends BaseEntity {
     public CowalkPost(CreateCowalkPostCommand command) {
         this.crewId = command.crewId();
         this.memberId = command.memberId();
-        this.startedAt = LocalDateTime.of(command.date(), command.time());
+        this.startedAt = command.startedAt();
+        this.endedAt = command.endedAt();
         this.capacity = command.capacity();
         this.capacityType = command.capacity() == null ? CapacityType.UNLIMITED : CapacityType.LIMITED;
         this.memo = command.memo();
@@ -48,7 +57,23 @@ public class CowalkPost extends BaseEntity {
             return;
 
         if (participantCount >= capacity) {
-            throw new CoreException(COWALK_PARTICIPANT_LIMIT);
+            throw new CoreException(CoreErrorCode.COWALK_PARTICIPANT_LIMIT);
+        }
+    }
+
+    public void validateCowalkDuration(LocalDateTime startedAt, LocalDateTime endedAt) {
+        if (startedAt == null || endedAt == null) {
+            throw new CoreException(CoreErrorCode.COWALK_STARTEDAT_ENDEDAT_NOTNULL);
+        }
+
+        if (endedAt.isBefore(startedAt)) {
+            throw new CoreException(CoreErrorCode.COWALK_STARTEDAT_EARLY_ENDEDAT);
+        }
+
+        Duration duration = Duration.between(startedAt, endedAt);
+        long durationMinutes = duration.toMinutes();
+        if (durationMinutes < MIN_DURATION_HOUR * 60 || durationMinutes > MAX_DURATION_HOUR * 60) {
+            throw new CoreException(CoreErrorCode.COWALK_DURATION_BETWEEN_1H_3H);
         }
     }
 
@@ -70,6 +95,10 @@ public class CowalkPost extends BaseEntity {
 
     public LocalDateTime getStartedAt() {
         return startedAt;
+    }
+
+    public LocalDateTime getEndedAt() {
+        return endedAt;
     }
 
     public Integer getCapacity() {

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPostRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/domain/CowalkPostRepository.java
@@ -3,7 +3,6 @@ package com.dongsan.domain.domains.cowalk.domain;
 import com.dongsan.domain.support.paging.CursorResponse;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
@@ -14,5 +13,5 @@ public interface CowalkPostRepository {
 
     CursorResponse<CowalkPost> getCowalkPosts(Integer size, Long lastId, Long crewId);
 
-    CursorResponse<CowalkPost> getJoinedCowalkPost(Long memberId, LocalDateTime twentyFourHoursAgo, Long lastId, int size);
+    CursorResponse<CowalkPost> getJoinedCowalkPost(Long memberId, Long lastId, int size);
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkPostCoreRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/infrastructure/CowalkPostCoreRepository.java
@@ -56,14 +56,15 @@ public class CowalkPostCoreRepository implements CowalkPostRepository {
     }
 
     @Override
-    public CursorResponse<CowalkPost> getJoinedCowalkPost(Long memberId, LocalDateTime twentyFourHoursAgo, Long lastId, int size) {
+    public CursorResponse<CowalkPost> getJoinedCowalkPost(Long memberId, Long lastId, int size) {
         CowalkPost lastCowalkPost = this.getCowalkPostEntity(lastId);
+        LocalDateTime now = LocalDateTime.now();
 
         List<CowalkPost> cowalkPosts = queryFactory.selectFrom(cowalkPost)
                 .join(cowalkParticipant).on(cowalkPost.id.eq(cowalkParticipant.cowalkPostId))
                 .where(cowalkParticipant.memberId.eq(memberId),
-                        cowalkPost.startedAt.gt(twentyFourHoursAgo),
-                        cowalkPostStartedAtLt(lastCowalkPost)
+                        cowalkPost.endedAt.gt(now),
+                        cowalkPostStartedAtGt(lastCowalkPost)
                 )
                 .orderBy(cowalkPost.startedAt.asc(), cowalkPost.id.asc())
                 .limit(size + 1L)
@@ -72,7 +73,7 @@ public class CowalkPostCoreRepository implements CowalkPostRepository {
         return new CursorResponse<>(cowalkPosts, size);
     }
 
-    private BooleanExpression cowalkPostStartedAtLt(CowalkPost lastCowalkPost) {
+    private BooleanExpression cowalkPostStartedAtGt(CowalkPost lastCowalkPost) {
         if (lastCowalkPost == null) {
             return null;
         }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkPostRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/cowalk/service/CowalkPostRdbService.java
@@ -8,8 +8,6 @@ import com.dongsan.domain.support.paging.CursorResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-
 import static com.dongsan.domain.support.error.CoreErrorCode.COWALK_NOT_FOUND;
 
 @Service
@@ -42,7 +40,6 @@ public class CowalkPostRdbService {
     }
 
     public CursorResponse<CowalkPost> getJoinedCowalkPost(Long memberId, Long lastId, int size) {
-        LocalDateTime twentyFourHoursAgo = LocalDateTime.now().minusHours(24);
-        return cowalkPostRepository.getJoinedCowalkPost(memberId, twentyFourHoursAgo, lastId, size);
+        return cowalkPostRepository.getJoinedCowalkPost(memberId, lastId, size);
     }
 }

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/walkway/domain/WalkwayInfo.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/walkway/domain/WalkwayInfo.java
@@ -28,10 +28,26 @@ public class WalkwayInfo {
     @Column(nullable = false, name = "distance")
     private Double distanceKm;
 
-    @Column(nullable = false, name = "time")
+    @Column(nullable = false, name = "startTime")
     private Integer timeSec;
 
     protected WalkwayInfo() {
+    }
+
+    public WalkwayInfo(String name, Double distanceKm, Integer timeSec, WalkwayExposeLevel exposeLevel, String memo, List<String> hashtags) {
+        name = name.trim();
+        memo = memo.trim();
+
+        validateName(name);
+        validateDistance(distanceKm);
+        validateTime(timeSec);
+
+        this.name = name;
+        this.distanceKm = distanceKm;
+        this.timeSec = timeSec;
+        this.exposeLevel = exposeLevel;
+        this.memo = memo;
+        this.hashtags = Objects.requireNonNullElseGet(hashtags, List::of);
     }
 
     private void validateName(String name) {
@@ -50,22 +66,6 @@ public class WalkwayInfo {
         if (time == null || time < MIN_TIME_SEC) {
             throw new CoreException(CoreErrorCode.WALKWAY_TIME_NOT_ENOUGH);
         }
-    }
-
-    public WalkwayInfo(String name, Double distanceKm, Integer timeSec, WalkwayExposeLevel exposeLevel, String memo, List<String> hashtags) {
-        name = name.trim();
-        memo = memo.trim();
-
-        validateName(name);
-        validateDistance(distanceKm);
-        validateTime(timeSec);
-
-        this.name = name;
-        this.distanceKm = distanceKm;
-        this.timeSec = timeSec;
-        this.exposeLevel = exposeLevel;
-        this.memo = memo;
-        this.hashtags = Objects.requireNonNullElseGet(hashtags, List::of);
     }
 
     public void updateWalkwayInfo(String name, String memo, WalkwayExposeLevel walkwayExposeLevel, List<String> hashtags) {

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/support/error/CoreErrorCode.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/support/error/CoreErrorCode.java
@@ -70,8 +70,9 @@ public enum CoreErrorCode {
     COWALK_PARTICIPANT_LIMIT(CoreErrorStatus.BAD_REQUEST, "COWALK-03", "같이 산책 인원이 이미 모두 찼습니다."),
     COWALK_LOCK_FAIL(CoreErrorStatus.CONFLICT, "COWALK-04", "같이 산책 참여에 실패했습니다."),
     COWALK_PARTICIPANT_NOT_JOIN(CoreErrorStatus.BAD_REQUEST, "COWALK-05", "같이 산책에 참여하지 않은 사용자입니다."),
-
-    ;
+    COWALK_STARTEDAT_ENDEDAT_NOTNULL(CoreErrorStatus.BAD_REQUEST, "COWALK-06", "같이 산책하기의 시작, 종료 시간은 null이 아닙니다."),
+    COWALK_STARTEDAT_EARLY_ENDEDAT(CoreErrorStatus.BAD_REQUEST, "COWALK-07", "같이 산책하기의 시작 시간은 종료 시간보다 일러야 합니다."),
+    COWALK_DURATION_BETWEEN_1H_3H(CoreErrorStatus.BAD_REQUEST, "COWALK-08", "종료 시간 - 시작 시간 : 1시간 이상 ~ 3시간 이하 입니다.");
 
     private final CoreErrorStatus httpStatus;
     private final String code;

--- a/dongsan-core/domain-rdb/src/test/java/com/dongsan/domain/domains/cowalk/domain/CowalkPostTest.java
+++ b/dongsan-core/domain-rdb/src/test/java/com/dongsan/domain/domains/cowalk/domain/CowalkPostTest.java
@@ -5,8 +5,7 @@ import com.dongsan.domain.support.error.CoreException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -23,7 +22,7 @@ class CowalkPostTest {
         String memo = "memo";
 
         CreateCowalkPostCommand command
-                = new CreateCowalkPostCommand(crewId, memberId, LocalDate.now(), LocalTime.now(), capacity, memo);
+                = new CreateCowalkPostCommand(crewId, memberId, LocalDateTime.now(), LocalDateTime.now().plusHours(2), capacity, memo);
 
         CowalkPost cowalkPost = new CowalkPost(command);
 

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/request/CreateCowalkPostRequest.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/request/CreateCowalkPostRequest.java
@@ -7,15 +7,23 @@ import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.Range;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public record CreateCowalkPostRequest(
-        @NotNull(message = "산책 날짜를 입력해주세요")
-        LocalDate date,
+        @NotNull(message = "산책 시작 날짜를 입력해주세요")
+        LocalDate startDate,
 
         @Schema(type = "string", example = "08:00:00", description = "산책 시작 시간")
-        @NotNull(message = "산책 시간을 입력해주세요")
-        LocalTime time,
+        @NotNull(message = "산책 시작 시간을 입력해주세요")
+        LocalTime startTime,
+
+        @NotNull(message = "산책 종료 날짜를 입력해주세요")
+        LocalDate endDate,
+
+        @Schema(type = "string", example = "08:00:00", description = "산책 종료 시간")
+        @NotNull(message = "산책 종료 시간을 입력해주세요")
+        LocalTime endTime,
 
         @NotNull(message = "인원 제한 여부를 입력해주세요")
         Boolean limitEnable,
@@ -30,8 +38,8 @@ public record CreateCowalkPostRequest(
         return new CreateCowalkPostCommand(
                 crewId,
                 memberId,
-                date,
-                time,
+                LocalDateTime.of(startDate, startTime),
+                LocalDateTime.of(endDate, endTime),
                 memberLimit,
                 memo
         );

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/GetMyCowalkResponse.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/dto/response/GetMyCowalkResponse.java
@@ -2,18 +2,17 @@ package com.dongsan.api.domains.cowalk.dto.response;
 
 import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record GetMyCowalkResponse(
         Long cowalkId,
-        LocalDate date,
-        LocalTime time
+        LocalDateTime startedAt,
+        LocalDateTime endedAt
 ) {
     public static List<GetMyCowalkResponse> from(List<CowalkPost> cowalkPostList) {
         return cowalkPostList.stream()
-                .map(c -> new GetMyCowalkResponse(c.getId(), c.getDate(), c.getTime()))
+                .map(c -> new GetMyCowalkResponse(c.getId(), c.getStartedAt(), c.getEndedAt()))
                 .toList();
     }
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/crew/CrewInfoFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/crew/CrewInfoFacade.java
@@ -1,19 +1,7 @@
 package com.dongsan.api.domains.crew;
 
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Map;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.dongsan.api.domains.crew.dto.request.CreateUpdateCrewRequest;
-import com.dongsan.api.domains.crew.dto.response.CreateCrewImageResponse;
-import com.dongsan.api.domains.crew.dto.response.GetCrewFeedResponse;
-import com.dongsan.api.domains.crew.dto.response.GetCrewInfoResponse;
-import com.dongsan.api.domains.crew.dto.response.GetCrewMemberRankingResponse;
-import com.dongsan.api.domains.crew.dto.response.GetCrewsResponse;
+import com.dongsan.api.domains.crew.dto.response.*;
 import com.dongsan.api.support.util.DateRangeUtil;
 import com.dongsan.domain.domains.crew.domain.Crew;
 import com.dongsan.domain.domains.crew.domain.CrewMember;
@@ -31,6 +19,13 @@ import com.dongsan.domain.support.error.CoreException;
 import com.dongsan.domain.support.paging.CursorRequest;
 import com.dongsan.domain.support.paging.CursorResponse;
 import com.dongsan.file.service.S3FileService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @Transactional
@@ -43,8 +38,8 @@ public class CrewInfoFacade {
     private final ImageRdbService imageRdbService;
 
     public CrewInfoFacade(CrewRdbService crewRdbService, CrewMemberRdbService crewMemberRdbService,
-            WalkwayLogRdbService walkwayLogRdbService, MemberRdbService memberRdbService, S3FileService s3FileService,
-            ImageRdbService imageRdbService) {
+                          WalkwayLogRdbService walkwayLogRdbService, MemberRdbService memberRdbService, S3FileService s3FileService,
+                          ImageRdbService imageRdbService) {
         this.crewRdbService = crewRdbService;
         this.crewMemberRdbService = crewMemberRdbService;
         this.walkwayLogRdbService = walkwayLogRdbService;
@@ -112,7 +107,7 @@ public class CrewInfoFacade {
         LocalDate startDate = DateRangeUtil.getStartOfWeek(LocalDate.now());
         LocalDate endDate = DateRangeUtil.getEndOfWeek(LocalDate.now());
         CrewWeeklyStatistic crewWeeklyStat = walkwayLogRdbService.getCrewWeeklyStat(crewId, startDate, endDate);
-        Long imageId = crew.getCrewImageUrl().isBlank()
+        Long imageId = crew.getCrewImageUrl() == null
                 ? null
                 : imageRdbService.getImageByUrl(crew.getCrewImageUrl()).getId();
         Long managerId = crewMemberRdbService.getManager(crew.getId()).getMemberId();
@@ -122,7 +117,7 @@ public class CrewInfoFacade {
 
     @Transactional(readOnly = true)
     public CursorResponse<GetCrewMemberRankingResponse> getCrewMemberRanking(Long crewId, Long memberId, LocalDate date,
-            CrewRankingSort sort, CrewRankingPeriod period, CursorRequest paging) {
+                                                                             CrewRankingSort sort, CrewRankingPeriod period, CursorRequest paging) {
         Crew crew = crewRdbService.getCrew(crewId);
         boolean isCrewMember = crewMemberRdbService.isCrewMember(crewId, memberId);
         crew.canAccess(isCrewMember);

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkPostFacadeTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkPostFacadeTest.java
@@ -2,8 +2,8 @@
 //
 // import static org.assertj.core.api.AssertionsForClassTypes.*;
 //
-// import java.time.LocalDate;
-// import java.time.LocalTime;
+// import java.startTime.LocalDate;
+// import java.startTime.LocalTime;
 // import java.util.concurrent.CountDownLatch;
 // import java.util.concurrent.ExecutorService;
 // import java.util.concurrent.Executors;


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

## 📄 Work Description
<strong>Jira Ticket : `DB-377`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. 같이 산책하기 등록 API - 종료 시간 추가
<img width="912" alt="스크린샷 2025-07-07 오후 2 08 17" src="https://github.com/user-attachments/assets/ca0aacda-74bd-4898-9d0d-b54873faf473" />


#### 2. 내가 신청한 같이 산책하기 조회 API - 종료 시각 추가
<img width="907" alt="스크린샷 2025-07-07 오후 2 08 41" src="https://github.com/user-attachments/assets/29945168-3cd5-4a5c-9fe2-86a2a3d4ae68" />



#### 3. .getCrewImage() null 처리

<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->


<br/>

## 🔗 Reference
[//]: # (문제를 해결하면서 도움이 되었거나 참고했던 사이트 또는 코드 첨부)
