### PR TITLE
[fix/DB-349]: DTO 수정 및 테이블 필드 매핑 수정

### DIFF
--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/walkway/domain/WalkwayInfo.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/walkway/domain/WalkwayInfo.java
@@ -28,7 +28,7 @@ public class WalkwayInfo {
     @Column(nullable = false, name = "distance")
     private Double distanceKm;
 
-    @Column(nullable = false, name = "startTime")
+    @Column(nullable = false, name = "time")
     private Integer timeSec;
 
     protected WalkwayInfo() {

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/walkway/service/WalkwayRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/walkway/service/WalkwayRdbService.java
@@ -33,9 +33,9 @@ public class WalkwayRdbService {
                 .orElseThrow(() -> new CoreException(CoreErrorCode.WALKWAY_NOT_FOUND));
     }
 
-//    public Optional<Walkway> findById(Long walkwayId) {
-//        return walkwayRepository.findById(walkwayId);
-//    }
+    public Optional<Walkway> findById(Long walkwayId) {
+        return walkwayRepository.findById(walkwayId);
+    }
 
     public Walkway getWalkwayWithAccessValidation(Long walkwayId, Long memberId) {
         Walkway walkway = getWalkway(walkwayId);

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/walkway/dto/request/CreateWalkwayRequest.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/walkway/dto/request/CreateWalkwayRequest.java
@@ -1,16 +1,11 @@
 package com.dongsan.api.domains.walkway.dto.request;
 
-import java.util.List;
-
 import com.dongsan.domain.domains.walkway.CreateWalkwayCommand;
 import com.dongsan.domain.domains.walkway.WalkwayCoordinate;
 import com.dongsan.domain.domains.walkway.domain.WalkwayExposeLevel;
+import jakarta.validation.constraints.*;
 
-import jakarta.validation.constraints.DecimalMin;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import java.util.List;
 
 public record CreateWalkwayRequest(
         @NotNull
@@ -26,7 +21,7 @@ public record CreateWalkwayRequest(
         Integer time,
         @NotNull
         List<String> hashtags,
-        WalkwayExposeLevel walkwayExposeLevel,
+        WalkwayExposeLevel exposeLevel,
         List<WalkwayCoordinate> course
 ) {
 
@@ -37,7 +32,7 @@ public record CreateWalkwayRequest(
                 distance,
                 time,
                 hashtags,
-                walkwayExposeLevel,
+                exposeLevel,
                 course,
                 imageUrl,
                 memberId

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/walkway/dto/request/UpdateWalkwayRequest.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/walkway/dto/request/UpdateWalkwayRequest.java
@@ -14,14 +14,14 @@ public record UpdateWalkwayRequest(
         @NotNull
         List<String> hashtags,
         @NotNull
-        WalkwayExposeLevel walkwayExposeLevel
+        WalkwayExposeLevel exposeLevel
 ) {
     public UpdateWalkwayCommand toUpdateWalkway(Long walkwayId) {
         return new UpdateWalkwayCommand(
                 walkwayId,
                 this.name(),
                 this.memo(),
-                this.walkwayExposeLevel(),
+                this.exposeLevel(),
                 this.hashtags()
         );
     }


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

## 📄 Work Description
<strong>Jira Ticket : `DB-349`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. 산책로 등록, 산책로 수정 API : DTO 필드 수정
DTO 필드를 walkwayExposeLevel → exposeLevel로 변경했습니다. 
enum 클래스 이름 변경하면서 인텔리제이 기능으로 DTO도 같이 변경된것 같습니다.


#### 2. Walkway 도메인 객체 테이블 매핑 필드 수정
시간 필드가 walkway 테이블의 time 필드와 매핑이 되어야 하는데, startTime이라는 필드와 매핑이 되어 있어서 해당 부분 수정했습니다.



