### PR TITLE
[refactor/DB-354]: 크루명 중복체크 API 수정

### DIFF
--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/crew/CrewInfoController.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/crew/CrewInfoController.java
@@ -35,7 +35,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 @RestController
 @RequestMapping("/crews")
@@ -52,7 +51,7 @@ public class CrewInfoController {
     @GetMapping("/exists")
     public ResponseEntity<IsNameUniqueResponse> isNameUnique(
             @RequestParam @NotBlank String name,
-            @RequestParam @NotNull Long crewId
+            @RequestParam(required = false) Long crewId
     ) {
         boolean isUnique = crewInfoFacade.isNameUnique(name, crewId);
         return ResponseEntity.ok(new IsNameUniqueResponse(isUnique));

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/crew/CrewInfoFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/crew/CrewInfoFacade.java
@@ -57,6 +57,9 @@ public class CrewInfoFacade {
     @Transactional(readOnly = true)
     public boolean isNameUnique(String name, Long crewId) {
         name = name.trim();
+        if (crewId == null) {
+            return !crewRdbService.isNameDuplicated(name);
+        }
         return !crewRdbService.isNameDuplicatedExceptSelf(name, crewId);
     }
 


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

## 📄 Work Description
<strong>Jira Ticket : `DB-354`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. API 수정
<img width="1443" height="515" alt="image" src="https://github.com/user-attachments/assets/0b9e2832-cbdb-4381-a5b4-6af75fe5f14f" />
<img width="494" height="169" alt="image" src="https://github.com/user-attachments/assets/11d07a7d-4c03-4873-8529-c2235b6ff37e" />
crewId가 null이면 isNameDuplicated로 전체 크루 목록에서 검증하게 수정했습니다.

<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->


<br/>

## 🔗 Reference
[//]: # (문제를 해결하면서 도움이 되었거나 참고했던 사이트 또는 코드 첨부)
