### PR TITLE
[fix/DB-357]: 크루 피드가 크루 생성 날짜 이후의 산책 기록만 보여주도록 수정

### DIFF
--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/walkwayLog/WalkwayLogCoreRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/walkwayLog/WalkwayLogCoreRepository.java
@@ -57,17 +57,25 @@ public class WalkwayLogCoreRepository implements WalkwayLogRepository {
     }
 
     @Override
-    public CursorResponse<WalkwayLog> getCrewWalkwayLog(Long crewId, LocalDateTime lastCreatedAt, int size) {
+    public CursorResponse<WalkwayLog> getCrewWalkwayLog(Long crewId, LocalDateTime crewCreatedAt, LocalDateTime lastCreatedAt, int size) {
         List<WalkwayLog> result = queryFactory
                 .selectFrom(walkwayLog)
                 .join(crewMember).on(crewMember.memberId.eq(walkwayLog.memberId))
                 .where(crewMember.crewId.eq(crewId),
-                        createdAtLt(lastCreatedAt))
+                        walkwayLogCreatedAtRange(crewCreatedAt, lastCreatedAt))
                 .orderBy(walkwayLog.createdAt.desc())
                 .limit((long) size + 1)
                 .fetch();
 
         return new CursorResponse<>(result, size);
+    }
+
+    private BooleanExpression walkwayLogCreatedAtRange(LocalDateTime crewCreatedAt, LocalDateTime lastCreatedAt) {
+        BooleanExpression expression = walkwayLog.createdAt.goe(crewCreatedAt);
+        if (lastCreatedAt != null) {
+            return expression.and(walkwayLog.createdAt.lt(lastCreatedAt));
+        }
+        return expression;
     }
 
     @Override

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/walkwayLog/WalkwayLogRdbService.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/walkwayLog/WalkwayLogRdbService.java
@@ -49,9 +49,9 @@ public class WalkwayLogRdbService {
         return walkwayLogRepository.getUserWalkwayLog(memberId, lastCreatedAt, size);
     }
 
-    public CursorResponse<WalkwayLog> getCrewFeed(Long crewId, Long lastWalkwayLogId, int size) {
+    public CursorResponse<WalkwayLog> getCrewFeed(Long crewId, LocalDateTime crewCreatedAt, Long lastWalkwayLogId, int size) {
         LocalDateTime lastCreatedAt = getWalkwayLogCreatedAt(lastWalkwayLogId);
-        return walkwayLogRepository.getCrewWalkwayLog(crewId, lastCreatedAt, size);
+        return walkwayLogRepository.getCrewWalkwayLog(crewId, crewCreatedAt, lastCreatedAt, size);
     }
 
     public CrewWeeklyStatistic getCrewWeeklyStat(Long crewId, LocalDate startDay, LocalDate endDay) {

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/walkwayLog/WalkwayLogRepository.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/domains/walkwayLog/WalkwayLogRepository.java
@@ -17,7 +17,7 @@ public interface WalkwayLogRepository {
 
     CursorResponse<WalkwayLog> getUserWalkwayLog(Long memberId, LocalDateTime lastCreatedAt, int size);
 
-    CursorResponse<WalkwayLog> getCrewWalkwayLog(Long crewId, LocalDateTime lastCreatedAt, int size);
+    CursorResponse<WalkwayLog> getCrewWalkwayLog(Long crewId, LocalDateTime crewCreatedAt, LocalDateTime lastCreatedAt, int size);
 
     CursorResponse<CrewMemberStatistic> getCrewRankingByDistance(Long crewId, Long lastMemberId, LocalDate startDay, LocalDate endDay, int size);
 

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/crew/CrewInfoFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/crew/CrewInfoFacade.java
@@ -1,20 +1,7 @@
 package com.dongsan.api.domains.crew;
 
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Map;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.dongsan.api.domains.crew.dto.request.CreateUpdateCrewRequest;
-import com.dongsan.api.domains.crew.dto.response.CreateCrewImageResponse;
-import com.dongsan.api.domains.crew.dto.response.GetCrewFeedResponse;
-import com.dongsan.api.domains.crew.dto.response.GetCrewInfoResponse;
-import com.dongsan.api.domains.crew.dto.response.GetCrewMemberRankingResponse;
-import com.dongsan.api.domains.crew.dto.response.GetCrewsResponse;
-import com.dongsan.api.domains.crew.dto.response.GetMyCrewIdsResponse;
+import com.dongsan.api.domains.crew.dto.response.*;
 import com.dongsan.api.support.util.DateRangeUtil;
 import com.dongsan.domain.domains.crew.domain.Crew;
 import com.dongsan.domain.domains.crew.domain.CrewMember;
@@ -32,6 +19,13 @@ import com.dongsan.domain.support.error.CoreException;
 import com.dongsan.domain.support.paging.CursorRequest;
 import com.dongsan.domain.support.paging.CursorResponse;
 import com.dongsan.file.service.S3FileService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @Transactional
@@ -44,8 +38,8 @@ public class CrewInfoFacade {
     private final ImageRdbService imageRdbService;
 
     public CrewInfoFacade(CrewRdbService crewRdbService, CrewMemberRdbService crewMemberRdbService,
-            WalkwayLogRdbService walkwayLogRdbService, MemberRdbService memberRdbService, S3FileService s3FileService,
-            ImageRdbService imageRdbService) {
+                          WalkwayLogRdbService walkwayLogRdbService, MemberRdbService memberRdbService, S3FileService s3FileService,
+                          ImageRdbService imageRdbService) {
         this.crewRdbService = crewRdbService;
         this.crewMemberRdbService = crewMemberRdbService;
         this.walkwayLogRdbService = walkwayLogRdbService;
@@ -98,7 +92,7 @@ public class CrewInfoFacade {
         boolean isCrewMember = crewMemberRdbService.isCrewMember(crewId, memberId);
         crew.canAccess(isCrewMember);
 
-        CursorResponse<WalkwayLog> walkwayLogs = walkwayLogRdbService.getCrewFeed(crewId, paging.lastId(),
+        CursorResponse<WalkwayLog> walkwayLogs = walkwayLogRdbService.getCrewFeed(crewId, crew.getCreatedAt(), paging.lastId(),
                 paging.size());
         List<Long> memberIds = walkwayLogs.getData().stream().map(WalkwayLog::getMemberId).toList();
         Map<Long, Member> memberMap = memberRdbService.getMemberMap(memberIds);
@@ -126,7 +120,7 @@ public class CrewInfoFacade {
 
     @Transactional(readOnly = true)
     public CursorResponse<GetCrewMemberRankingResponse> getCrewMemberRanking(Long crewId, Long memberId, LocalDate date,
-            CrewRankingSort sort, CrewRankingPeriod period, CursorRequest paging) {
+                                                                             CrewRankingSort sort, CrewRankingPeriod period, CursorRequest paging) {
         Crew crew = crewRdbService.getCrew(crewId);
         boolean isCrewMember = crewMemberRdbService.isCrewMember(crewId, memberId);
         crew.canAccess(isCrewMember);


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

## 📄 Work Description
<strong>Jira Ticket : `DB-357`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. 크루 피드가 크루 생성 날짜 이후의 산책 기록만 보여주도록 수정
수정 전 : 크루 피드 탭에 크루 생성 날짜 이전의 산책 기록도 보였음
수정 후 : 크루 생성 날짜 이후의 산책 기록만 보이도록 수정

