### PR TITLE
[test/DB-361]: 산책로 통합 테스트 코드

### DIFF
--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/support/error/CoreErrorCode.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/support/error/CoreErrorCode.java
@@ -22,7 +22,7 @@ public enum CoreErrorCode {
     ALREADY_REVIEWED(CoreErrorStatus.CONFLICT, "WALKWAY-08", "이미 리뷰를 작성하였습니다."),
     WALKWAY_NAME_NOT_BLANK(CoreErrorStatus.BAD_REQUEST, "WALKWAY-10", "산책로 이름은 공백일 수 없습니다."),
     WALKWAY_DISTANCE_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-11", "산책로 등록 가능 거리는 0.2km 이상입니다."),
-    WALKWAY_TIME_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-12", "산책로 등록 가능 시간은 10분(600초) 이상 입니다."),
+    WALKWAY_TIME_NOT_ENOUGH(CoreErrorStatus.BAD_REQUEST, "WALKWAY-12", "산책로 등록 가능 시간은 5분(300초) 이상 입니다."),
 
     // member
     MEMBER_NOT_FOUND(CoreErrorStatus.NOT_FOUND, "MEMBER-01", "해당 회원이 존재하지 않습니다."),

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/support/paging/CursorResponse.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/support/paging/CursorResponse.java
@@ -2,25 +2,16 @@ package com.dongsan.domain.support.paging;
 
 import java.util.List;
 
-public class CursorResponse<T> {
-    private final List<T> data;
-    private final boolean hasNext;
-
+public record CursorResponse<T>(
+        List<T> data,
+        boolean hasNext
+) {
+    // size 기반 생성 로직을 추가하고 싶으면 보조 생성자로 작성 가능
     public CursorResponse(List<T> data, int size) {
-        this.hasNext = data.size() > size;
-        this.data = hasNext ? List.copyOf(data.subList(0, size)) : List.copyOf(data);
+        this(data.size() > size ? List.copyOf(data.subList(0, size)) : List.copyOf(data),
+                data.size() > size);
     }
 
-    public CursorResponse(List<T> data, boolean hasNext) {
-        this.data = List.copyOf(data);
-        this.hasNext = hasNext;
-    }
-
-    public List<T> getData() {
-        return data;
-    }
-
-    public boolean getHasNext() {
-        return hasNext;
-    }
+    // 기본 생성자는 record가 자동 제공하는 canonical constructor
 }
+

--- a/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/support/paging/CursorResponse.java
+++ b/dongsan-core/domain-rdb/src/main/java/com/dongsan/domain/support/paging/CursorResponse.java
@@ -6,12 +6,9 @@ public record CursorResponse<T>(
         List<T> data,
         boolean hasNext
 ) {
-    // size 기반 생성 로직을 추가하고 싶으면 보조 생성자로 작성 가능
     public CursorResponse(List<T> data, int size) {
         this(data.size() > size ? List.copyOf(data.subList(0, size)) : List.copyOf(data),
                 data.size() > size);
     }
-
-    // 기본 생성자는 record가 자동 제공하는 canonical constructor
 }
 

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/bookmark/BookmarkController.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/bookmark/BookmarkController.java
@@ -1,16 +1,25 @@
 package com.dongsan.api.domains.bookmark;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.dongsan.api.domains.auth.CustomAuthUser;
 import com.dongsan.domain.domains.bookmark.domain.Bookmark;
 import com.dongsan.domain.support.paging.CursorRequest;
 import com.dongsan.domain.support.paging.CursorResponse;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Tag(name = "북마크")
@@ -101,6 +110,6 @@ public class BookmarkController {
     ) {
         CursorResponse<Bookmark> response = bookmarkFacade.getUserBookmark(customOAuth2User.getMemberId(),
                 new CursorRequest(lastId, size));
-        return ResponseEntity.ok(new CursorResponse<>(BookmarksNameResponse.from(response.getData()), response.getHasNext()));
+        return ResponseEntity.ok(new CursorResponse<>(BookmarksNameResponse.from(response.data()), response.hasNext()));
     }
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/bookmark/BookmarkFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/bookmark/BookmarkFacade.java
@@ -1,5 +1,11 @@
 package com.dongsan.api.domains.bookmark;
 
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.dongsan.domain.domains.bookmark.domain.Bookmark;
 import com.dongsan.domain.domains.bookmark.domain.MarkedWalkway;
 import com.dongsan.domain.domains.bookmark.service.BookmarkRdbService;
@@ -10,11 +16,6 @@ import com.dongsan.domain.domains.walkway.service.LikedWalkwayRdbService;
 import com.dongsan.domain.domains.walkway.service.WalkwayRdbService;
 import com.dongsan.domain.support.paging.CursorRequest;
 import com.dongsan.domain.support.paging.CursorResponse;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Map;
 
 @Component
 @Transactional
@@ -63,13 +64,13 @@ public class BookmarkFacade {
         bookmark.validateOwner(memberId);
         CursorResponse<MarkedWalkway> markedWalkways = bookmarkRdbService.getBookmarkWalkway(memberId, bookmarkId, paging.lastId(), paging.size());
 
-        List<Long> walkwayIds = markedWalkways.getData().stream().map(MarkedWalkway::getWalkwayId).toList();
+        List<Long> walkwayIds = markedWalkways.data().stream().map(MarkedWalkway::getWalkwayId).toList();
         Map<Long, Walkway> walkwayMap = walkwayRdbService.getWalkways(walkwayIds);
         Map<Long, ReviewStatistic> reviewStatMap = reviewRdbService.getReviewStats(walkwayIds);
         Map<Long, Long> likeCountMap = likedWalkwayRdbService.countLikesMap(walkwayIds);
 
-        List<MarkedWalkwayResponse> response = MarkedWalkwayResponse.from(markedWalkways.getData(), walkwayMap, reviewStatMap, likeCountMap);
-        return new CursorResponse<>(response, markedWalkways.getHasNext());
+        List<MarkedWalkwayResponse> response = MarkedWalkwayResponse.from(markedWalkways.data(), walkwayMap, reviewStatMap, likeCountMap);
+        return new CursorResponse<>(response, markedWalkways.hasNext());
     }
 
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
@@ -1,5 +1,13 @@
 package com.dongsan.api.domains.cowalk;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.dongsan.api.domains.cowalk.dto.request.CreateCowalkCommentRequest;
 import com.dongsan.api.domains.cowalk.dto.request.CreateCowalkPostRequest;
 import com.dongsan.api.domains.cowalk.dto.response.CowalkCommentResponse;
@@ -18,13 +26,6 @@ import com.dongsan.domain.lock.CowalkPostLockService;
 import com.dongsan.domain.support.error.CoreErrorCode;
 import com.dongsan.domain.support.error.CoreException;
 import com.dongsan.domain.support.paging.CursorResponse;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.List;
-import java.util.Map;
 
 @Service
 public class CowalkPostFacade {
@@ -86,7 +87,7 @@ public class CowalkPostFacade {
 
     public CursorResponse<CowalkPostsResponse> getCowalkPosts(Long crewId, Integer size, Long lastId) {
         CursorResponse<CowalkPost> cowalkPosts = cowalkPostRdbService.getCowalkPosts(size, lastId, crewId);
-        List<CowalkPost> cowalkPostList = cowalkPosts.getData();
+        List<CowalkPost> cowalkPostList = cowalkPosts.data();
 
         List<Long> memberIds = cowalkPostList.stream()
                 .map(CowalkPost::getMemberId)
@@ -106,7 +107,7 @@ public class CowalkPostFacade {
                 commentCountMap
         );
 
-        return new CursorResponse<>(cowalkPostsResponseList, cowalkPosts.getHasNext());
+        return new CursorResponse<>(cowalkPostsResponseList, cowalkPosts.hasNext());
     }
 
     @Transactional
@@ -123,7 +124,7 @@ public class CowalkPostFacade {
         CursorResponse<CowalkComment> cowalkComments
                 = cowalkCommentRdbService.getCowalkComments(size, lastId, cowalkPostId);
 
-        List<CowalkComment> cowalkCommentList = cowalkComments.getData();
+        List<CowalkComment> cowalkCommentList = cowalkComments.data();
 
         List<Long> memberIds = cowalkCommentList.stream()
                 .map(CowalkComment::getMemberId)
@@ -133,7 +134,7 @@ public class CowalkPostFacade {
 
         List<CowalkCommentResponse> responseList = CowalkCommentResponse.from(cowalkCommentList, memberMap);
 
-        return new CursorResponse<>(responseList, cowalkComments.getHasNext());
+        return new CursorResponse<>(responseList, cowalkComments.hasNext());
     }
 
     private LocalDate calculateEndDate(LocalDate startDate, LocalTime startTime, LocalTime endTime) {

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/MyCowalkFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/MyCowalkFacade.java
@@ -1,11 +1,12 @@
 package com.dongsan.api.domains.cowalk;
 
+import org.springframework.stereotype.Service;
+
 import com.dongsan.api.domains.cowalk.dto.response.GetMyCowalkResponse;
 import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
 import com.dongsan.domain.domains.cowalk.service.CowalkPostRdbService;
 import com.dongsan.domain.support.paging.CursorRequest;
 import com.dongsan.domain.support.paging.CursorResponse;
-import org.springframework.stereotype.Service;
 
 @Service
 public class MyCowalkFacade {
@@ -17,6 +18,6 @@ public class MyCowalkFacade {
 
     public CursorResponse<GetMyCowalkResponse> getMyCowalk(CursorRequest cursorRequest, Long memberId) {
         CursorResponse<CowalkPost> result = cowalkPostRdbService.getJoinedCowalkPost(memberId, cursorRequest.lastId(), cursorRequest.size());
-        return new CursorResponse<>(GetMyCowalkResponse.from(result.getData()), result.getHasNext());
+        return new CursorResponse<>(GetMyCowalkResponse.from(result.data()), result.hasNext());
     }
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/crew/CrewInfoFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/crew/CrewInfoFacade.java
@@ -1,7 +1,20 @@
 package com.dongsan.api.domains.crew;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
 import com.dongsan.api.domains.crew.dto.request.CreateUpdateCrewRequest;
-import com.dongsan.api.domains.crew.dto.response.*;
+import com.dongsan.api.domains.crew.dto.response.CreateCrewImageResponse;
+import com.dongsan.api.domains.crew.dto.response.GetCrewFeedResponse;
+import com.dongsan.api.domains.crew.dto.response.GetCrewInfoResponse;
+import com.dongsan.api.domains.crew.dto.response.GetCrewMemberRankingResponse;
+import com.dongsan.api.domains.crew.dto.response.GetCrewsResponse;
+import com.dongsan.api.domains.crew.dto.response.GetMyCrewIdsResponse;
 import com.dongsan.api.support.util.DateRangeUtil;
 import com.dongsan.domain.domains.crew.domain.Crew;
 import com.dongsan.domain.domains.crew.domain.CrewMember;
@@ -19,13 +32,6 @@ import com.dongsan.domain.support.error.CoreException;
 import com.dongsan.domain.support.paging.CursorRequest;
 import com.dongsan.domain.support.paging.CursorResponse;
 import com.dongsan.file.service.S3FileService;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Map;
 
 @Service
 public class CrewInfoFacade {
@@ -95,10 +101,10 @@ public class CrewInfoFacade {
 
         CursorResponse<WalkwayLog> walkwayLogs = walkwayLogRdbService.getCrewFeed(crewId, crew.getCreatedAt(), paging.lastId(),
                 paging.size());
-        List<Long> memberIds = walkwayLogs.getData().stream().map(WalkwayLog::getMemberId).toList();
+        List<Long> memberIds = walkwayLogs.data().stream().map(WalkwayLog::getMemberId).toList();
         Map<Long, Member> memberMap = memberRdbService.getMemberMap(memberIds);
         List<GetCrewFeedResponse> result = GetCrewFeedResponse.from(walkwayLogs, memberMap);
-        return new CursorResponse<>(result, walkwayLogs.getHasNext());
+        return new CursorResponse<>(result, walkwayLogs.hasNext());
     }
 
     @Transactional(readOnly = true)
@@ -134,10 +140,10 @@ public class CrewInfoFacade {
             case DURATION ->
                     walkwayLogRdbService.getCrewRankingByTime(crewId, paging.lastId(), startDay, endDay, paging.size());
         };
-        List<Long> memberIds = response.getData().stream().map(CrewMemberStatistic::memberId).toList();
+        List<Long> memberIds = response.data().stream().map(CrewMemberStatistic::memberId).toList();
         Map<Long, Member> memberMap = memberRdbService.getMemberMap(memberIds);
-        List<GetCrewMemberRankingResponse> result = GetCrewMemberRankingResponse.from(response.getData(), memberMap);
-        return new CursorResponse<>(result, response.getHasNext());
+        List<GetCrewMemberRankingResponse> result = GetCrewMemberRankingResponse.from(response.data(), memberMap);
+        return new CursorResponse<>(result, response.hasNext());
     }
 
     @Transactional
@@ -157,20 +163,20 @@ public class CrewInfoFacade {
 
     public CursorResponse<GetCrewsResponse> getMyCrews(Long memberId, CursorRequest paging) {
         CursorResponse<Crew> crews = crewRdbService.getMyCrews(memberId, paging.size(), paging.lastId());
-        List<GetCrewsResponse> result = this.getCrewsResponseList(crews.getData(), memberId);
-        return new CursorResponse<>(result, crews.getHasNext());
+        List<GetCrewsResponse> result = this.getCrewsResponseList(crews.data(), memberId);
+        return new CursorResponse<>(result, crews.hasNext());
     }
 
     public CursorResponse<GetCrewsResponse> searchCrews(Long memberId, String name, CursorRequest paging) {
         CursorResponse<Crew> crews = crewRdbService.searchCrews(name, paging.size(), paging.lastId());
-        List<GetCrewsResponse> result = this.getCrewsResponseList(crews.getData(), memberId);
-        return new CursorResponse<>(result, crews.getHasNext());
+        List<GetCrewsResponse> result = this.getCrewsResponseList(crews.data(), memberId);
+        return new CursorResponse<>(result, crews.hasNext());
     }
 
     public CursorResponse<GetCrewsResponse> recommendCrews(Long memberId, CursorRequest paging) {
         CursorResponse<Crew> crews = crewRdbService.recommendCrews(paging.size(), paging.lastId(), memberId);
-        List<GetCrewsResponse> result = this.getCrewsResponseList(crews.getData(), memberId);
-        return new CursorResponse<>(result, crews.getHasNext());
+        List<GetCrewsResponse> result = this.getCrewsResponseList(crews.data(), memberId);
+        return new CursorResponse<>(result, crews.hasNext());
     }
 
     private List<GetCrewsResponse> getCrewsResponseList(List<Crew> crewList, Long memberId) {

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/crew/dto/response/GetCrewFeedResponse.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/crew/dto/response/GetCrewFeedResponse.java
@@ -1,12 +1,12 @@
 package com.dongsan.api.domains.crew.dto.response;
 
-import com.dongsan.domain.domains.member.Member;
-import com.dongsan.domain.domains.walkwayLog.WalkwayLog;
-import com.dongsan.domain.support.paging.CursorResponse;
-
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+
+import com.dongsan.domain.domains.member.Member;
+import com.dongsan.domain.domains.walkwayLog.WalkwayLog;
+import com.dongsan.domain.support.paging.CursorResponse;
 
 public record GetCrewFeedResponse(
         Long walkwayHistoryId,
@@ -17,7 +17,7 @@ public record GetCrewFeedResponse(
         int durationSec
 ) {
     public static List<GetCrewFeedResponse> from(CursorResponse<WalkwayLog> walkwayLogs, Map<Long, Member> memberMap) {
-        return walkwayLogs.getData().stream()
+        return walkwayLogs.data().stream()
                 .map(walkwayLog -> {
                     Member member = memberMap.get(walkwayLog.getMemberId());
                     if (member == null) {

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/review/ReviewController.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/review/ReviewController.java
@@ -1,5 +1,17 @@
 package com.dongsan.api.domains.review;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.dongsan.api.domains.auth.CustomAuthUser;
 import com.dongsan.api.domains.review.dto.CreateReviewRequest;
 import com.dongsan.api.domains.review.dto.CreateReviewResponse;
@@ -8,13 +20,9 @@ import com.dongsan.domain.domains.review.domain.ReviewStatistic;
 import com.dongsan.domain.domains.review.infrastructure.ReviewWithMemberQuery;
 import com.dongsan.domain.support.paging.CursorRequest;
 import com.dongsan.domain.support.paging.CursorResponse;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/walkways")
@@ -53,7 +61,7 @@ public class ReviewController {
                 = reviewFacade.getWalkwayReviews(sort, walkwayId, customOAuth2User.getMemberId(),
                 new CursorRequest(lastId, size));
         return ResponseEntity.ok(
-                new CursorResponse<>(WalkwayReviewsResponse.from(response.getData()), response.getHasNext()));
+                new CursorResponse<>(WalkwayReviewsResponse.from(response.data()), response.hasNext()));
     }
 
     @Operation(summary = "리뷰 별점 보기")

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/review/UserReviewController.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/review/UserReviewController.java
@@ -1,12 +1,5 @@
 package com.dongsan.api.domains.review;
 
-import com.dongsan.api.domains.auth.CustomAuthUser;
-import com.dongsan.api.domains.review.dto.MyReviewResponse;
-import com.dongsan.domain.domains.review.infrastructure.ReviewWithWalkwayQuery;
-import com.dongsan.domain.support.paging.CursorRequest;
-import com.dongsan.domain.support.paging.CursorResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -14,6 +7,15 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.dongsan.api.domains.auth.CustomAuthUser;
+import com.dongsan.api.domains.review.dto.MyReviewResponse;
+import com.dongsan.domain.domains.review.infrastructure.ReviewWithWalkwayQuery;
+import com.dongsan.domain.support.paging.CursorRequest;
+import com.dongsan.domain.support.paging.CursorResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping("/users/reviews")
@@ -38,7 +40,7 @@ public class UserReviewController {
     ) {
         CursorResponse<ReviewWithWalkwayQuery> response = userReviewFacade.getUserReviews(new CursorRequest(lastId, size),
                 customOAuth2User.getMemberId());
-        return ResponseEntity.ok(new CursorResponse<>(MyReviewResponse.from(response.getData()), response.getHasNext()));
+        return ResponseEntity.ok(new CursorResponse<>(MyReviewResponse.from(response.data()), response.hasNext()));
     }
 
 }

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/walkway/UserWalkwayFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/walkway/UserWalkwayFacade.java
@@ -1,5 +1,11 @@
 package com.dongsan.api.domains.walkway;
 
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.dongsan.api.domains.walkway.dto.response.WalkwayLogWithReviewResponse;
 import com.dongsan.api.domains.walkway.dto.response.WalkwaySimpleResponse;
 import com.dongsan.domain.domains.review.domain.Review;
@@ -13,11 +19,6 @@ import com.dongsan.domain.domains.walkwayLog.WalkwayLog;
 import com.dongsan.domain.domains.walkwayLog.WalkwayLogRdbService;
 import com.dongsan.domain.support.paging.CursorRequest;
 import com.dongsan.domain.support.paging.CursorResponse;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Map;
 
 @Service
 public class UserWalkwayFacade {
@@ -36,36 +37,36 @@ public class UserWalkwayFacade {
     @Transactional(readOnly = true)
     public CursorResponse<WalkwaySimpleResponse> getUserWalkway(Long memberId, CursorRequest paging) {
         CursorResponse<Walkway> walkways = walkwayRdbService.getUserWalkway(memberId, paging.lastId(), paging.size());
-        List<WalkwaySnapshot> walkwaySnapshots = walkways.getData().stream().map(Walkway::snapshot).toList();
-        List<Long> walkwayIds = walkways.getData().stream().map(Walkway::getId).toList();
+        List<WalkwaySnapshot> walkwaySnapshots = walkways.data().stream().map(Walkway::snapshot).toList();
+        List<Long> walkwayIds = walkways.data().stream().map(Walkway::getId).toList();
         Map<Long, ReviewStatistic> reviewStatMap = reviewRdbService.getReviewStats(walkwayIds);
         Map<Long, Long> likeCountMap = likedWalkwayRdbService.countLikesMap(walkwayIds);
         List<WalkwaySimpleResponse> responses = WalkwaySimpleResponse.from(walkwaySnapshots, reviewStatMap, likeCountMap);
-        return new CursorResponse<>(responses, walkways.getHasNext());
+        return new CursorResponse<>(responses, walkways.hasNext());
     }
 
     @Transactional(readOnly = true)
     public CursorResponse<WalkwaySimpleResponse> getUserLikedWalkway(Long memberId, CursorRequest paging) {
         CursorResponse<Walkway> walkways = walkwayRdbService.getUserLikedWalkway(memberId, paging.lastId(), paging.size());
-        List<WalkwaySnapshot> walkwaySnapshots = walkways.getData().stream().map(Walkway::snapshot).toList();
-        List<Long> walkwayIds = walkways.getData().stream().map(Walkway::getId).toList();
+        List<WalkwaySnapshot> walkwaySnapshots = walkways.data().stream().map(Walkway::snapshot).toList();
+        List<Long> walkwayIds = walkways.data().stream().map(Walkway::getId).toList();
         Map<Long, ReviewStatistic> reviewStatMap = reviewRdbService.getReviewStats(walkwayIds);
         Map<Long, Long> likeCountMap = likedWalkwayRdbService.countLikesMap(walkwayIds);
         List<WalkwaySimpleResponse> responses = WalkwaySimpleResponse.from(walkwaySnapshots, reviewStatMap, likeCountMap);
-        return new CursorResponse<>(responses, walkways.getHasNext());
+        return new CursorResponse<>(responses, walkways.hasNext());
     }
 
     @Transactional(readOnly = true)
     public CursorResponse<WalkwayLogWithReviewResponse> getUserWalkwayHistoryWithReview(Long memberId, CursorRequest paging) {
         CursorResponse<WalkwayLog> walkwayLogs = walkwayLogRdbService.getUserWalkwayLog(memberId, paging.lastId(), paging.size());
-        List<Long> walkwayIds = walkwayLogs.getData().stream().map(WalkwayLog::getWalkwayId).toList();
-        List<Long> walkwayLogIds = walkwayLogs.getData().stream().map(WalkwayLog::getId).toList();
+        List<Long> walkwayIds = walkwayLogs.data().stream().map(WalkwayLog::getWalkwayId).toList();
+        List<Long> walkwayLogIds = walkwayLogs.data().stream().map(WalkwayLog::getId).toList();
         Map<Long, Walkway> walkwayMap = walkwayRdbService.getWalkways(walkwayIds);  // {walkwayId, Walkway}
         Map<Long, ReviewStatistic> reviewStatMap = reviewRdbService.getReviewStats(walkwayIds);  // {walkwayId, ReviewStatistic}
         Map<Long, Long> likeCountMap = likedWalkwayRdbService.countLikesMap(walkwayIds);  // {walkwayId, likeCount}
         Map<Long, Review> reviewMap = reviewRdbService.getReviews(walkwayLogIds);  // {walkwayLogId, Review}
-        List<WalkwayLogWithReviewResponse> response = WalkwayLogWithReviewResponse.from(walkwayLogs.getData(), walkwayMap, reviewMap, reviewStatMap, likeCountMap);
-        return new CursorResponse<>(response, walkwayLogs.getHasNext());
+        List<WalkwayLogWithReviewResponse> response = WalkwayLogWithReviewResponse.from(walkwayLogs.data(), walkwayMap, reviewMap, reviewStatMap, likeCountMap);
+        return new CursorResponse<>(response, walkwayLogs.hasNext());
     }
 
 

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/walkway/WalkwayController.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/walkway/WalkwayController.java
@@ -1,23 +1,39 @@
 package com.dongsan.api.domains.walkway;
 
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
 import com.dongsan.api.domains.auth.CustomAuthUser;
 import com.dongsan.api.domains.walkway.dto.request.CreateWalkwayHistoryRequest;
 import com.dongsan.api.domains.walkway.dto.request.CreateWalkwayRequest;
 import com.dongsan.api.domains.walkway.dto.request.UpdateWalkwayRequest;
-import com.dongsan.api.domains.walkway.dto.response.*;
+import com.dongsan.api.domains.walkway.dto.response.BookmarksWithMarkedWalkwayResponse;
+import com.dongsan.api.domains.walkway.dto.response.CourseImageIdResponse;
+import com.dongsan.api.domains.walkway.dto.response.SearchWalkwayResponse;
+import com.dongsan.api.domains.walkway.dto.response.WalkwayDetailResponse;
+import com.dongsan.api.domains.walkway.dto.response.WalkwayHistoryResponse;
+import com.dongsan.api.domains.walkway.dto.response.WalkwayIdResponse;
 import com.dongsan.domain.domains.bookmark.infrastructure.dto.BookmarkWithMarkedStatus;
 import com.dongsan.domain.domains.walkway.SearchWalkwayQuery;
 import com.dongsan.domain.domains.walkway.UpdateWalkwayCommand;
 import com.dongsan.domain.support.paging.CursorRequest;
 import com.dongsan.domain.support.paging.CursorResponse;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/walkways")
@@ -97,7 +113,7 @@ public class WalkwayController {
         CursorResponse<BookmarkWithMarkedStatus> response
                 = walkwayFacade.getBookmarksWithMarkedWalkway(customOAuth2User.getMemberId(), walkwayId, new CursorRequest(lastId, size));
         return ResponseEntity.ok(
-                new CursorResponse<>(BookmarksWithMarkedWalkwayResponse.from(response.getData()), response.getHasNext()));
+                new CursorResponse<>(BookmarksWithMarkedWalkwayResponse.from(response.data()), response.hasNext()));
     }
 
     @Operation(summary = "산책로 검색")

--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/walkway/WalkwayFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/walkway/WalkwayFacade.java
@@ -1,5 +1,13 @@
 package com.dongsan.api.domains.walkway;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
 import com.dongsan.api.domains.walkway.dto.request.CreateWalkwayRequest;
 import com.dongsan.api.domains.walkway.dto.response.SearchWalkwayResponse;
 import com.dongsan.api.domains.walkway.dto.response.WalkwayDetailResponse;
@@ -25,13 +33,6 @@ import com.dongsan.domain.domains.walkwayLog.WalkwayLogRdbService;
 import com.dongsan.domain.support.paging.CursorRequest;
 import com.dongsan.domain.support.paging.CursorResponse;
 import com.dongsan.file.service.S3FileService;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 @Service
 public class WalkwayFacade {
@@ -121,15 +122,15 @@ public class WalkwayFacade {
     @Transactional(readOnly = true)
     public CursorResponse<SearchWalkwayResponse> searchWalkway(SearchWalkwayQuery searchQuery, CursorRequest paging) {
         CursorResponse<Walkway> walkways = searchWalkwayFactory.getService(searchQuery.sort()).search(searchQuery, paging);
-        List<Long> walkwayIds = walkways.getData().stream().map(Walkway::getId).toList();
-        List<WalkwaySnapshot> walkwaySnapshots = walkways.getData().stream().map(Walkway::snapshot).toList();
+        List<Long> walkwayIds = walkways.data().stream().map(Walkway::getId).toList();
+        List<WalkwaySnapshot> walkwaySnapshots = walkways.data().stream().map(Walkway::snapshot).toList();
 
         Map<Long, ReviewStatistic> reviewStatMap = reviewRdbService.getReviewStats(walkwayIds);
         Map<Long, Long> likeCountMap = likedWalkwayRdbService.countLikesMap(walkwayIds);
         Set<Long> likedWalkwaySet = likedWalkwayRdbService.likedWalkways(searchQuery.memberId(), walkwayIds);
 
         List<SearchWalkwayResponse> response = SearchWalkwayResponse.from(walkwaySnapshots, reviewStatMap, likeCountMap, likedWalkwaySet);
-        return new CursorResponse<>(response, walkways.getHasNext());
+        return new CursorResponse<>(response, walkways.hasNext());
     }
 
     @Transactional(readOnly = true)
@@ -140,15 +141,15 @@ public class WalkwayFacade {
             case RATING -> walkwayRdbService.getWalkwaysRating(memberId, paging.lastId(), paging.size());
             default -> walkwayRdbService.getWalkwaysLatest(memberId, paging.lastId(), paging.size());
         };
-        List<Long> walkwayIds = walkways.getData().stream().map(Walkway::getId).toList();
-        List<WalkwaySnapshot> walkwaySnapshots = walkways.getData().stream().map(Walkway::snapshot).toList();
+        List<Long> walkwayIds = walkways.data().stream().map(Walkway::getId).toList();
+        List<WalkwaySnapshot> walkwaySnapshots = walkways.data().stream().map(Walkway::snapshot).toList();
 
         Map<Long, ReviewStatistic> reviewStatMap = reviewRdbService.getReviewStats(walkwayIds);
         Map<Long, Long> likeCountMap = likedWalkwayRdbService.countLikesMap(walkwayIds);
         Set<Long> likedWalkwaySet = likedWalkwayRdbService.likedWalkways(memberId, walkwayIds);
 
         List<SearchWalkwayResponse> response = SearchWalkwayResponse.from(walkwaySnapshots, reviewStatMap, likeCountMap, likedWalkwaySet);
-        return new CursorResponse<>(response, walkways.getHasNext());
+        return new CursorResponse<>(response, walkways.hasNext());
     }
 
 }

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/walkway/LikedWalkwayIntegrationTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/walkway/LikedWalkwayIntegrationTest.java
@@ -1,0 +1,123 @@
+package com.dongsan.api.domains.walkway;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.dongsan.api.support.IntegrationTest;
+import com.dongsan.api.support.TestAuthHelper;
+import com.dongsan.api.support.factory.ImageFactory;
+import com.dongsan.api.support.factory.LikedWalkwayFactory;
+import com.dongsan.api.support.factory.WalkwayFactory;
+import com.dongsan.api.support.factory.WalkwayLogFactory;
+
+public class LikedWalkwayIntegrationTest extends IntegrationTest {
+    @Autowired
+    private TestAuthHelper authHelper;
+    @Autowired
+    private WalkwayFactory walkwayFactory;
+    @Autowired
+    private ImageFactory imageFactory;
+    @Autowired
+    private LikedWalkwayFactory likedWalkwayFactory;
+    @Autowired
+    private WalkwayLogFactory walkwayLogFactory;
+
+    @Test
+    void createLikedWalkwayTest() {
+        imageFactory.save();
+        Long walkwayId = walkwayFactory.save();
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways/" + walkwayId + "/likes",
+                HttpMethod.POST,
+                entity,
+                Void.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void createLikedWalkwayTest_walkway_not_exists() {
+        imageFactory.save();
+        Long walkwayId = 999L;
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways/" + walkwayId + "/likes",
+                HttpMethod.POST,
+                entity,
+                Void.class
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    void deleteLikedWalkwayTest() {
+        imageFactory.save();
+        Long walkwayId = walkwayFactory.save();
+        Long memberId = 1L;
+        likedWalkwayFactory.save(memberId, walkwayId);
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways/" + walkwayId + "/likes",
+                HttpMethod.DELETE,
+                entity,
+                Void.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void deleteLikedWalkwayTest_walkway_not_exists() {
+        imageFactory.save();
+        Long walkwayId = 999L;
+        Long memberId = 1L;
+        likedWalkwayFactory.save(memberId, walkwayId);
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways/" + walkwayId + "/likes",
+                HttpMethod.DELETE,
+                entity,
+                Void.class
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    void deleteLikedWalkwayTest_walkwayLiked_not_exists() {
+        imageFactory.save();
+        Long walkwayId = walkwayFactory.save();
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways/" + walkwayId + "/likes",
+                HttpMethod.DELETE,
+                entity,
+                Void.class
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    }
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/walkway/LikedWalkwayIntegrationTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/walkway/LikedWalkwayIntegrationTest.java
@@ -17,7 +17,7 @@ import com.dongsan.api.support.factory.LikedWalkwayFactory;
 import com.dongsan.api.support.factory.WalkwayFactory;
 import com.dongsan.api.support.factory.WalkwayLogFactory;
 
-public class LikedWalkwayIntegrationTest extends IntegrationTest {
+class LikedWalkwayIntegrationTest extends IntegrationTest {
     @Autowired
     private TestAuthHelper authHelper;
     @Autowired

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/walkway/UserWalkwayIntegrationTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/walkway/UserWalkwayIntegrationTest.java
@@ -23,7 +23,7 @@ import com.dongsan.api.support.factory.WalkwayFactory;
 import com.dongsan.api.support.factory.WalkwayLogFactory;
 import com.dongsan.domain.support.paging.CursorResponse;
 
-public class UserWalkwayIntegrationTest extends IntegrationTest {
+class UserWalkwayIntegrationTest extends IntegrationTest {
     @Autowired
     private TestAuthHelper authHelper;
     @Autowired
@@ -38,7 +38,7 @@ public class UserWalkwayIntegrationTest extends IntegrationTest {
     @Test
     void getUserUploadWalkwayTest() {
         imageFactory.save();
-        Long walkwayId = walkwayFactory.save();
+        walkwayFactory.save();
         Long memberId = 1L;
         HttpHeaders headers = authHelper.generateTokenHeader(memberId);
         HttpEntity<String> entity = new HttpEntity<>(headers);

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/walkway/UserWalkwayIntegrationTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/walkway/UserWalkwayIntegrationTest.java
@@ -1,0 +1,109 @@
+package com.dongsan.api.domains.walkway;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.dongsan.api.domains.walkway.dto.response.WalkwayLogWithReviewResponse;
+import com.dongsan.api.domains.walkway.dto.response.WalkwaySimpleResponse;
+import com.dongsan.api.support.IntegrationTest;
+import com.dongsan.api.support.TestAuthHelper;
+import com.dongsan.api.support.factory.ImageFactory;
+import com.dongsan.api.support.factory.LikedWalkwayFactory;
+import com.dongsan.api.support.factory.WalkwayFactory;
+import com.dongsan.api.support.factory.WalkwayLogFactory;
+import com.dongsan.domain.support.paging.CursorResponse;
+
+public class UserWalkwayIntegrationTest extends IntegrationTest {
+    @Autowired
+    private TestAuthHelper authHelper;
+    @Autowired
+    private WalkwayFactory walkwayFactory;
+    @Autowired
+    private ImageFactory imageFactory;
+    @Autowired
+    private LikedWalkwayFactory likedWalkwayFactory;
+    @Autowired
+    private WalkwayLogFactory walkwayLogFactory;
+
+    @Test
+    void getUserUploadWalkwayTest() {
+        imageFactory.save();
+        Long walkwayId = walkwayFactory.save();
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<CursorResponse<WalkwaySimpleResponse>> response = restTemplate.exchange(
+                "http://localhost:" + port + "/users/walkways/upload",
+                HttpMethod.GET,
+                entity,
+                new ParameterizedTypeReference<CursorResponse<WalkwaySimpleResponse>>() {
+                }
+        );
+
+        int expectedSize = 1;
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assertions.assertNotNull(response.getBody());
+        assertThat(expectedSize).isEqualTo(response.getBody().data().size());
+    }
+
+    @Test
+    void getUserLikedWalkwayTest() {
+        imageFactory.save();
+        Long walkwayId = walkwayFactory.save();
+        Long memberId = 1L;
+        likedWalkwayFactory.save(memberId, walkwayId);
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<CursorResponse<WalkwaySimpleResponse>> response = restTemplate.exchange(
+                "http://localhost:" + port + "/users/walkways/like",
+                HttpMethod.GET,
+                entity,
+                new ParameterizedTypeReference<CursorResponse<WalkwaySimpleResponse>>() {
+                }
+        );
+
+        int expectedSize = 1;
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assertions.assertNotNull(response.getBody());
+        assertThat(expectedSize).isEqualTo(response.getBody().data().size());
+    }
+
+    @Test
+    void getUserWalkwayHistoryTest() {
+        imageFactory.save();
+        Long walkwayId1 = walkwayFactory.save();
+        Long walkwayId2 = walkwayFactory.save();
+        Long memberId = 1L;
+        walkwayLogFactory.save(memberId, walkwayId1, 300, 0.2);
+        walkwayLogFactory.save(memberId, walkwayId2, 300, 0.1);
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<CursorResponse<WalkwayLogWithReviewResponse>> response = restTemplate.exchange(
+                "http://localhost:" + port + "/users/walkways/history",
+                HttpMethod.GET,
+                entity,
+                new ParameterizedTypeReference<CursorResponse<WalkwayLogWithReviewResponse>>() {
+                }
+        );
+
+        int expectedSize = 2;
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assertions.assertNotNull(response.getBody());
+        assertThat(expectedSize).isEqualTo(response.getBody().data().size());
+        assertThat(response.getBody().data().get(0).canReview()).isFalse();
+        assertThat(response.getBody().data().get(1).canReview()).isTrue();
+    }
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/walkway/WalkwayIntegrationTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/walkway/WalkwayIntegrationTest.java
@@ -35,7 +35,7 @@ import com.dongsan.api.support.factory.WalkwayFactory;
 import com.dongsan.domain.support.paging.CursorResponse;
 import com.dongsan.file.service.S3FileService;
 
-public class WalkwayIntegrationTest extends IntegrationTest {
+class WalkwayIntegrationTest extends IntegrationTest {
     @Autowired
     private TestAuthHelper authHelper;
     @Autowired

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/walkway/WalkwayIntegrationTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/walkway/WalkwayIntegrationTest.java
@@ -1,0 +1,452 @@
+package com.dongsan.api.domains.walkway;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.dongsan.api.domains.walkway.dto.response.BookmarksWithMarkedWalkwayResponse;
+import com.dongsan.api.domains.walkway.dto.response.CourseImageIdResponse;
+import com.dongsan.api.domains.walkway.dto.response.SearchWalkwayResponse;
+import com.dongsan.api.domains.walkway.dto.response.WalkwayDetailResponse;
+import com.dongsan.api.domains.walkway.dto.response.WalkwayHistoryResponse;
+import com.dongsan.api.domains.walkway.dto.response.WalkwayIdResponse;
+import com.dongsan.api.support.IntegrationTest;
+import com.dongsan.api.support.TestAuthHelper;
+import com.dongsan.api.support.factory.BookmarkFactory;
+import com.dongsan.api.support.factory.ImageFactory;
+import com.dongsan.api.support.factory.MarkedWalkwayFactory;
+import com.dongsan.api.support.factory.WalkwayFactory;
+import com.dongsan.domain.support.paging.CursorResponse;
+import com.dongsan.file.service.S3FileService;
+
+public class WalkwayIntegrationTest extends IntegrationTest {
+    @Autowired
+    private TestAuthHelper authHelper;
+    @Autowired
+    private WalkwayFactory walkwayFactory;
+    @Autowired
+    private ImageFactory imageFactory;
+    @Autowired
+    private BookmarkFactory bookmarkFactory;
+    @Autowired
+    private MarkedWalkwayFactory markedWalkwayFactory;
+    @MockBean
+    private S3FileService s3FileService;
+
+    @Test
+    void createWalkwayTest() {
+        imageFactory.save();
+
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        String jsonBody = """
+                {
+                    "courseImageId": 1,
+                    "name": "test",
+                    "memo": "test memo",
+                    "distance": 0.2,
+                    "time": 300,
+                    "hashtags": ["test"],
+                    "exposeLevel": "PUBLIC",
+                    "course": [
+                        {
+                          "latitude": 1,
+                          "longitude": 1
+                        },
+                        {
+                          "latitude": 2,
+                          "longitude": 2
+                        }
+                    ]
+                }
+                """;
+        HttpEntity<String> entity = new HttpEntity<>(jsonBody, headers);
+
+        ResponseEntity<WalkwayIdResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways",
+                HttpMethod.POST,
+                entity,
+                WalkwayIdResponse.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assertions.assertNotNull(response.getBody());
+    }
+
+    @Test
+    void createWalkwayTest_image_not_exists() {
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        String jsonBody = """
+                {
+                    "courseImageId": 1,
+                    "name": "test",
+                    "memo": "test memo",
+                    "distance": 0.2,
+                    "time": 300,
+                    "hashtags": ["test"],
+                    "exposeLevel": "PUBLIC",
+                    "course": [
+                        {
+                          "latitude": 1,
+                          "longitude": 1
+                        },
+                        {
+                          "latitude": 2,
+                          "longitude": 2
+                        }
+                    ]
+                }
+                """;
+        HttpEntity<String> entity = new HttpEntity<>(jsonBody, headers);
+
+        ResponseEntity<WalkwayIdResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways",
+                HttpMethod.POST,
+                entity,
+                WalkwayIdResponse.class
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    void createWalkwayCourseImageTest() {
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+
+        // given: S3 업로드 호출 시 가짜 URL 반환
+        given(s3FileService.saveFile(any(MultipartFile.class)))
+                .willReturn("https://test/");
+
+        // multipart/form-data 요청 준비
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+        ByteArrayResource resource = new ByteArrayResource("fakeImage".getBytes()) {
+            @Override
+            public String getFilename() {
+                return "course.png";
+            }
+        };
+
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("courseImage", resource); // @RequestPart("courseImage")와 동일 이름
+
+        // when
+        ResponseEntity<CourseImageIdResponse> response = restTemplate.postForEntity(
+                "http://localhost:" + port + "/walkways/image",
+                new HttpEntity<>(body, headers),
+                CourseImageIdResponse.class
+        );
+
+        // then
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assertions.assertNotNull(response.getBody());
+    }
+
+    @Test
+    void updateWalkwayTest() {
+        imageFactory.save();
+        Long walkwayId = walkwayFactory.save();
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        String jsonBody = """
+                {
+                    "name": "update",
+                    "memo": "update memo",
+                    "hashtags": ["test", "update"],
+                    "exposeLevel": "PRIVATE"
+                }
+                """;
+        HttpEntity<String> entity = new HttpEntity<>(jsonBody, headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways/" + walkwayId,
+                HttpMethod.PUT,
+                entity,
+                Void.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void updateWalkwayTest_walkway_not_exists() {
+        imageFactory.save();
+        Long walkwayId = 999L;
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        String jsonBody = """
+                {
+                    "name": "update",
+                    "memo": "update memo",
+                    "hashtags": ["test", "update"],
+                    "exposeLevel": "PRIVATE"
+                }
+                """;
+        HttpEntity<String> entity = new HttpEntity<>(jsonBody, headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways/" + walkwayId,
+                HttpMethod.PUT,
+                entity,
+                Void.class
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    void deleteWalkwayTest() {
+        imageFactory.save();
+        Long walkwayId = walkwayFactory.save();
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways/" + walkwayId,
+                HttpMethod.DELETE,
+                entity,
+                Void.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void deleteWalkwayTest_walkway_not_exists() {
+        imageFactory.save();
+        Long walkwayId = 999L;
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways/" + walkwayId,
+                HttpMethod.DELETE,
+                entity,
+                Void.class
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    void getWalkwayTest() {
+        imageFactory.save();
+        Long walkwayId = walkwayFactory.save();
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<WalkwayDetailResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways/" + walkwayId,
+                HttpMethod.GET,
+                entity,
+                WalkwayDetailResponse.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assertions.assertNotNull(response.getBody());
+    }
+
+    @Test
+    void getWalkwayTest_walkway_not_exists() {
+        imageFactory.save();
+        Long walkwayId = 999L;
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<WalkwayDetailResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways/" + walkwayId,
+                HttpMethod.GET,
+                entity,
+                WalkwayDetailResponse.class
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    void getBookmarksWithMarkedWalkwayTest() {
+        imageFactory.save();
+        Long walkwayId = walkwayFactory.save();
+        Long memberId = 1L;
+        Long bookmarkId = bookmarkFactory.save(memberId);
+        markedWalkwayFactory.save(bookmarkId, walkwayId);
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<CursorResponse<BookmarksWithMarkedWalkwayResponse>> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways/" + walkwayId + "/bookmarks?size=10",
+                HttpMethod.GET,
+                entity,
+                new ParameterizedTypeReference<CursorResponse<BookmarksWithMarkedWalkwayResponse>>() {
+                }
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assertions.assertNotNull(response.getBody());
+        assertThat(bookmarkId).isEqualTo(response.getBody().data().get(0).bookmarkId());
+    }
+
+    @Test
+    void searchWalkwayTest() {
+        imageFactory.save();
+        Long walkwayId = walkwayFactory.save();
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<CursorResponse<SearchWalkwayResponse>> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways?sort=liked&latitude=37.5&longitude=127.0&distance=2.0",
+                HttpMethod.GET,
+                entity,
+                new ParameterizedTypeReference<CursorResponse<SearchWalkwayResponse>>() {
+                }
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assertions.assertNotNull(response.getBody());
+        assertThat(walkwayId).isEqualTo(response.getBody().data().get(0).walkwayId());
+    }
+
+    @Test
+    void getWalkwaysLatest() {
+        imageFactory.save();
+        Long walkwayId = walkwayFactory.save();
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<CursorResponse<SearchWalkwayResponse>> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways/all?sort=liked",
+                HttpMethod.GET,
+                entity,
+                new ParameterizedTypeReference<CursorResponse<SearchWalkwayResponse>>() {
+                }
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assertions.assertNotNull(response.getBody());
+        assertThat(walkwayId).isEqualTo(response.getBody().data().get(0).walkwayId());
+    }
+
+    @Test
+    void createHistoryTest() {
+        imageFactory.save();
+        Long walkwayId = walkwayFactory.save();
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        String jsonBody = """
+                {
+                    "time": 10,
+                    "distance": 0.3
+                }
+                """;
+        HttpEntity<String> entity = new HttpEntity<>(jsonBody, headers);
+
+        ResponseEntity<WalkwayHistoryResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways/" + walkwayId + "/history",
+                HttpMethod.POST,
+                entity,
+                WalkwayHistoryResponse.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assertions.assertNotNull(response.getBody());
+    }
+
+    @Test
+    void createHistoryTest_walkway_not_exists() {
+        imageFactory.save();
+        Long walkwayId = 999L;
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        String jsonBody = """
+                {
+                    "time": 10,
+                    "distance": 0.3
+                }
+                """;
+        HttpEntity<String> entity = new HttpEntity<>(jsonBody, headers);
+
+        ResponseEntity<WalkwayHistoryResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways/" + walkwayId + "/history",
+                HttpMethod.POST,
+                entity,
+                WalkwayHistoryResponse.class
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        Assertions.assertNotNull(response.getBody());
+    }
+
+    @Test
+    void createHistoryTest_wrong_time() {
+        imageFactory.save();
+        Long walkwayId = walkwayFactory.save();
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        String jsonBody = """
+                {
+                    "time": -100,
+                    "distance": 0.3
+                }
+                """;
+        HttpEntity<String> entity = new HttpEntity<>(jsonBody, headers);
+
+        ResponseEntity<WalkwayHistoryResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways/" + walkwayId + "/history",
+                HttpMethod.POST,
+                entity,
+                WalkwayHistoryResponse.class
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        Assertions.assertNotNull(response.getBody());
+    }
+
+    @Test
+    void createHistoryTest_wrong_distance() {
+        imageFactory.save();
+        Long walkwayId = walkwayFactory.save();
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        String jsonBody = """
+                {
+                    "time": 10,
+                    "distance": -0.3
+                }
+                """;
+        HttpEntity<String> entity = new HttpEntity<>(jsonBody, headers);
+
+        ResponseEntity<WalkwayHistoryResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/walkways/" + walkwayId + "/history",
+                HttpMethod.POST,
+                entity,
+                WalkwayHistoryResponse.class
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        Assertions.assertNotNull(response.getBody());
+    }
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/support/IntegrationTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/support/IntegrationTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.jdbc.Sql;
@@ -15,6 +16,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Testcontainers
 @Sql(scripts = "classpath:/reset.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)

--- a/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/BookmarkFactory.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/BookmarkFactory.java
@@ -1,0 +1,17 @@
+package com.dongsan.api.support.factory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.dongsan.domain.domains.bookmark.domain.Bookmark;
+import com.dongsan.domain.domains.bookmark.domain.BookmarkRepository;
+
+@Component
+public class BookmarkFactory {
+    @Autowired
+    private BookmarkRepository bookmarkRepository;
+
+    public Long save(Long memberId) {
+        return bookmarkRepository.save(new Bookmark("test", memberId));
+    }
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/ImageFactory.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/ImageFactory.java
@@ -7,7 +7,7 @@ import com.dongsan.domain.domains.image.ImageRepository;
 
 @Component
 public class ImageFactory {
-    String DEFAULT_IMAGE_URL = "test image url";
+    private static final String DEFAULT_IMAGE_URL = "test image url";
 
     @Autowired
     private ImageRepository imageRepository;

--- a/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/ImageFactory.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/ImageFactory.java
@@ -1,0 +1,18 @@
+package com.dongsan.api.support.factory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.dongsan.domain.domains.image.ImageRepository;
+
+@Component
+public class ImageFactory {
+    String DEFAULT_IMAGE_URL = "test image url";
+
+    @Autowired
+    private ImageRepository imageRepository;
+
+    public Long save() {
+        return imageRepository.save(DEFAULT_IMAGE_URL);
+    }
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/LikedWalkwayFactory.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/LikedWalkwayFactory.java
@@ -1,0 +1,17 @@
+package com.dongsan.api.support.factory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.dongsan.domain.domains.walkway.domain.LikedWalkway;
+import com.dongsan.domain.domains.walkway.domain.LikedWalkwayRepository;
+
+@Component
+public class LikedWalkwayFactory {
+    @Autowired
+    private LikedWalkwayRepository likedWalkwayRepository;
+
+    public void save(Long memberId, Long walkwayId) {
+        likedWalkwayRepository.save(new LikedWalkway(memberId, walkwayId));
+    }
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/MarkedWalkwayFactory.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/MarkedWalkwayFactory.java
@@ -1,0 +1,16 @@
+package com.dongsan.api.support.factory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.dongsan.domain.domains.bookmark.domain.MarkedWalkwayRepository;
+
+@Component
+public class MarkedWalkwayFactory {
+    @Autowired
+    private MarkedWalkwayRepository markedWalkwayRepository;
+
+    public void save(Long bookmarkId, Long walkwayId) {
+        markedWalkwayRepository.includeWalkway(bookmarkId, walkwayId);
+    }
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/WalkwayFactory.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/WalkwayFactory.java
@@ -20,20 +20,20 @@ import com.dongsan.domain.domains.walkway.domain.WalkwayRepository;
 
 @Component
 public class WalkwayFactory {
-    LineString DEFAULT_COURSE = LineStringMapper.toLineString(
+    private static final LineString DEFAULT_COURSE = LineStringMapper.toLineString(
             List.of(
                     new WalkwayCoordinate(37.5000, 127.0000),
                     new WalkwayCoordinate(37.5010, 127.0010),
                     new WalkwayCoordinate(37.5020, 127.0020)
             )
     );
-    String DEFAULT_NAME = "test Walkway";
-    String DEFAULT_MEMO = "test memo";
-    String DEFAULT_IMAGE_URL = "test image url";
-    Double DEFAULT_DISTANCE = 0.2;
-    Integer DEFAULT_TIME = 300;
-    List<String> DEFAULT_HASHTAG = List.of("test");
-    Long DEFAULT_MEMBER_ID = 1L;
+    private static final String DEFAULT_NAME = "test Walkway";
+    private static final String DEFAULT_MEMO = "test memo";
+    private static final String DEFAULT_IMAGE_URL = "test image url";
+    private static final Double DEFAULT_DISTANCE = 0.2;
+    private static final Integer DEFAULT_TIME = 300;
+    private static final List<String> DEFAULT_HASHTAG = List.of("test");
+    private static final Long DEFAULT_MEMBER_ID = 1L;
 
 
     @Autowired

--- a/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/WalkwayFactory.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/WalkwayFactory.java
@@ -1,0 +1,56 @@
+package com.dongsan.api.support.factory;
+
+import java.util.List;
+
+import org.locationtech.jts.geom.LineString;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.dongsan.domain.domains.walkway.LineStringMapper;
+import com.dongsan.domain.domains.walkway.WalkwayCoordinate;
+import com.dongsan.domain.domains.walkway.domain.MetaWalkwayLiked;
+import com.dongsan.domain.domains.walkway.domain.MetaWalkwayLikedRepository;
+import com.dongsan.domain.domains.walkway.domain.MetaWalkwayRating;
+import com.dongsan.domain.domains.walkway.domain.MetaWalkwayRatingRepository;
+import com.dongsan.domain.domains.walkway.domain.Walkway;
+import com.dongsan.domain.domains.walkway.domain.WalkwayExposeLevel;
+import com.dongsan.domain.domains.walkway.domain.WalkwayGeometry;
+import com.dongsan.domain.domains.walkway.domain.WalkwayInfo;
+import com.dongsan.domain.domains.walkway.domain.WalkwayRepository;
+
+@Component
+public class WalkwayFactory {
+    LineString DEFAULT_COURSE = LineStringMapper.toLineString(
+            List.of(
+                    new WalkwayCoordinate(37.5000, 127.0000),
+                    new WalkwayCoordinate(37.5010, 127.0010),
+                    new WalkwayCoordinate(37.5020, 127.0020)
+            )
+    );
+    String DEFAULT_NAME = "test Walkway";
+    String DEFAULT_MEMO = "test memo";
+    String DEFAULT_IMAGE_URL = "test image url";
+    Double DEFAULT_DISTANCE = 0.2;
+    Integer DEFAULT_TIME = 300;
+    List<String> DEFAULT_HASHTAG = List.of("test");
+    Long DEFAULT_MEMBER_ID = 1L;
+
+
+    @Autowired
+    private WalkwayRepository walkwayRepository;
+    @Autowired
+    private MetaWalkwayLikedRepository metaWalkwayLikedRepository;
+    @Autowired
+    private MetaWalkwayRatingRepository metaWalkwayRatingRepository;
+
+    public Long save() {
+        WalkwayGeometry walkwayGeometry = new WalkwayGeometry(DEFAULT_COURSE, DEFAULT_IMAGE_URL);
+        WalkwayInfo walkwayInfo = new WalkwayInfo(DEFAULT_NAME, DEFAULT_DISTANCE, DEFAULT_TIME, WalkwayExposeLevel.PUBLIC, DEFAULT_MEMO, DEFAULT_HASHTAG);
+        Walkway walkway = new Walkway(DEFAULT_MEMBER_ID, walkwayInfo, walkwayGeometry);
+        walkwayRepository.save(walkway);
+        metaWalkwayLikedRepository.save(new MetaWalkwayLiked(walkway.getId()));
+        metaWalkwayRatingRepository.save(new MetaWalkwayRating(walkway.getId()));
+        return walkway.getId();
+    }
+
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/WalkwayLogFactory.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/WalkwayLogFactory.java
@@ -1,0 +1,17 @@
+package com.dongsan.api.support.factory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.dongsan.domain.domains.walkwayLog.WalkwayLog;
+import com.dongsan.domain.domains.walkwayLog.WalkwayLogRepository;
+
+@Component
+public class WalkwayLogFactory {
+    @Autowired
+    private WalkwayLogRepository walkwayLogRepository;
+
+    public void save(Long memberId, Long walkwayId, Integer time, Double distance) {
+        walkwayLogRepository.save(new WalkwayLog(memberId, walkwayId, time, distance));
+    }
+}


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

## 📄 Work Description
<strong>Jira Ticket : `DB-361`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. 산책로 관련 테스트
<img width="435" height="658" alt="image" src="https://github.com/user-attachments/assets/69bf2a22-3a52-4356-b6ca-c7a46a11feac" />

기존 `MemberIntegrationTest` 를 참고해서 작성했습니다.

<img width="372" height="284" alt="image" src="https://github.com/user-attachments/assets/29b82a2b-6db6-491f-9ca4-285b3bc0e97d" />
<img width="1100" height="725" alt="image" src="https://github.com/user-attachments/assets/cd851c65-d19b-406f-8b2c-c158b598ee81" />

factory 클래스를 만들어서 필요 Entity를 생성하고 테스트 DB에 저장하도록 했습니다.

#### 2. CursorResponse Record로 리팩토링
<img width="641" height="190" alt="image" src="https://github.com/user-attachments/assets/862329b2-ec9b-4cce-ab32-81523f579941" />

기존에도 불변 객체였고, 테스트하면서 역직렬화(json -> class)에서 에러가 나서 변경했습니다. 

#### 3. 통합 테스트 DB 연결 에러 수정
한번에 여러 통합 테스트를 실행시키면 커넥션 풀에서 커넥션을 가져오지 못하는 문제가 생겼습니다... ㅜㅜ
테스트 컨테이너는 변경되었지만 스프링이 Context를 재사용하면서 발생한 문제였습니다.
`@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)` 를 추가해서 해결했습니다.
<img width="800" height="881" alt="image" src="https://github.com/user-attachments/assets/b28cb064-df98-43b5-a5d7-8c62826a9b8e" />

참고 : https://prod.velog.io/@tjddus0302/Spring-DirtiesContext

<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->


<br/>

## 🔗 Reference
[//]: # (문제를 해결하면서 도움이 되었거나 참고했던 사이트 또는 코드 첨부)
