### PR TITLE
[test/DB-370]: 크루, 같이 산책 테스트 코드

### DIFF
--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkIntegrationTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkIntegrationTest.java
@@ -1,0 +1,247 @@
+package com.dongsan.api.domains.cowalk;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.dongsan.api.domains.cowalk.dto.response.CowalkCommentResponse;
+import com.dongsan.api.domains.cowalk.dto.response.CowalkPostDetailResponse;
+import com.dongsan.api.domains.cowalk.dto.response.CowalkPostsResponse;
+import com.dongsan.api.domains.cowalk.dto.response.CreateCowalkCommentResponse;
+import com.dongsan.api.domains.cowalk.dto.response.CreateCowalkPostResponse;
+import com.dongsan.api.domains.cowalk.dto.response.JoinCowalkParticipantResponse;
+import com.dongsan.api.support.IntegrationTest;
+import com.dongsan.api.support.TestAuthHelper;
+import com.dongsan.api.support.factory.CowalkCommentFactory;
+import com.dongsan.api.support.factory.CowalkParticipantFactory;
+import com.dongsan.api.support.factory.CowalkPostFactory;
+import com.dongsan.api.support.factory.CrewFactory;
+import com.dongsan.domain.domains.crew.domain.CrewExposeLevel;
+import com.dongsan.domain.support.paging.CursorResponse;
+
+public class CowalkIntegrationTest extends IntegrationTest {
+    @Autowired
+    private TestAuthHelper authHelper;
+    @Autowired
+    private CrewFactory crewFactory;
+    @Autowired
+    private CowalkPostFactory cowalkPostFactory;
+    @Autowired
+    private CowalkParticipantFactory cowalkParticipantFactory;
+    @Autowired
+    private CowalkCommentFactory cowalkCommentFactory;
+
+    @Test
+    void createCowalkPostTest() {
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        Long crewId = crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+
+        String jsonBody = """
+                {
+                    "startDate": "%s",
+                    "startTime": "%s",
+                    "endTime": "%s",
+                    "limitEnable": true,
+                    "memberLimit": 10,
+                    "memo": "같이산책 내용"
+                }
+                """.formatted(LocalDate.now(), LocalTime.now(), LocalTime.now().plusHours(1));
+
+        HttpEntity<String> entity = new HttpEntity<>(jsonBody, headers);
+
+        ResponseEntity<CreateCowalkPostResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/" + crewId + "/cowalk",
+                HttpMethod.POST,
+                entity,
+                CreateCowalkPostResponse.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assertions.assertNotNull(response.getBody());
+    }
+
+    @Test
+    void getCowalkPostTest() {
+        Long memberId = 1L;
+        Long crewId = crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+        cowalkPostFactory.save(crewId, memberId);
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<CowalkPostDetailResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/" + crewId + "/cowalk/1",
+                HttpMethod.GET,
+                entity,
+                CowalkPostDetailResponse.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1L, response.getBody().cowalkId());
+    }
+
+    @Test
+    void joinParticipantTest() {
+        Long memberId = 1L;
+        Long crewId = crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+        cowalkPostFactory.save(crewId, memberId);
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<JoinCowalkParticipantResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/" + crewId + "/cowalk/1/join",
+                HttpMethod.POST,
+                entity,
+                JoinCowalkParticipantResponse.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void joinParticipantTest_crew_not_exists() {
+        Long memberId = 1L;
+        Long crewId = 999L;
+        cowalkPostFactory.save(crewId, memberId);
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<JoinCowalkParticipantResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/" + crewId + "/cowalk/1/join",
+                HttpMethod.POST,
+                entity,
+                JoinCowalkParticipantResponse.class
+        );
+
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+    }
+
+    @Test
+    void joinParticipantTest_cowalk_not_exists() {
+        Long memberId = 1L;
+        Long crewId = crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+        cowalkPostFactory.save(crewId, memberId);
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<JoinCowalkParticipantResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/" + crewId + "/cowalk/999/join",
+                HttpMethod.POST,
+                entity,
+                JoinCowalkParticipantResponse.class
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    void getCowalkPostsTest() {
+        Long memberId = 1L;
+        Long crewId = crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+        cowalkPostFactory.save(crewId, memberId);
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<CursorResponse<CowalkPostsResponse>> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/" + crewId + "/cowalk",
+                HttpMethod.GET,
+                entity,
+                new ParameterizedTypeReference<CursorResponse<CowalkPostsResponse>>() {
+                }
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody().data().size());
+    }
+
+    @Test
+    void createCowalkCommentTest() {
+        Long memberId = 1L;
+        Long crewId = crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+        cowalkPostFactory.save(crewId, memberId);
+        cowalkParticipantFactory.save(1L, memberId);
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+
+        String jsonBody = """
+                {
+                    "content": "오홍홍 좋아요"
+                }
+        """;
+
+        HttpEntity<String> entity = new HttpEntity<>(jsonBody, headers);
+
+        ResponseEntity<CreateCowalkCommentResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/" + crewId + "/cowalk/1/comments",
+                HttpMethod.POST,
+                entity,
+                CreateCowalkCommentResponse.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void createCowalkCommentTest_not_participant() {
+        Long memberId = 1L;
+        Long crewId = crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+        cowalkPostFactory.save(crewId, memberId);
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+
+        String jsonBody = """
+                {
+                    "content": "오홍홍 좋아요"
+                }
+        """;
+
+        HttpEntity<String> entity = new HttpEntity<>(jsonBody, headers);
+
+        ResponseEntity<CreateCowalkCommentResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/" + crewId + "/cowalk/1/comments",
+                HttpMethod.POST,
+                entity,
+                CreateCowalkCommentResponse.class
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    }
+
+    @Test
+    void getCowalkCommentsTest() {
+        Long memberId = 1L;
+        Long crewId = crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+        cowalkPostFactory.save(crewId, memberId);
+        cowalkParticipantFactory.save(1L, memberId);
+        cowalkCommentFactory.save(1L, memberId);
+
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<CursorResponse<CowalkCommentResponse>> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/" + crewId + "/cowalk/1/comments",
+                HttpMethod.GET,
+                entity,
+                new ParameterizedTypeReference<CursorResponse<CowalkCommentResponse>>() {
+                }
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody().data().size());
+    }
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkIntegrationTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkIntegrationTest.java
@@ -30,7 +30,7 @@ import com.dongsan.api.support.factory.CrewFactory;
 import com.dongsan.domain.domains.crew.domain.CrewExposeLevel;
 import com.dongsan.domain.support.paging.CursorResponse;
 
-public class CowalkIntegrationTest extends IntegrationTest {
+class CowalkIntegrationTest extends IntegrationTest {
     @Autowired
     private TestAuthHelper authHelper;
     @Autowired

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkPostFacadeTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkPostFacadeTest.java
@@ -1,105 +1,103 @@
-// package com.dongsan.api.domains.cowalk;
-//
-// import static org.assertj.core.api.AssertionsForClassTypes.*;
-//
-// import java.startTime.LocalDate;
-// import java.startTime.LocalTime;
-// import java.util.concurrent.CountDownLatch;
-// import java.util.concurrent.ExecutorService;
-// import java.util.concurrent.Executors;
-//
-// import org.junit.jupiter.api.BeforeEach;
-// import org.junit.jupiter.api.Test;
-// import org.springframework.beans.factory.annotation.Autowired;
-//
-// import com.dongsan.api.support.IntegrationTest;
-// import com.dongsan.domain.domains.auth.Provider;
-// import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
-// import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
-// import com.dongsan.domain.domains.cowalk.infrastructure.CowalkParticipantCoreRepository;
-// import com.dongsan.domain.domains.cowalk.infrastructure.CowalkPostCoreRepository;
-// import com.dongsan.domain.domains.crew.domain.Capacity;
-// import com.dongsan.domain.domains.crew.domain.Crew;
-// import com.dongsan.domain.domains.crew.domain.CrewMember;
-// import com.dongsan.domain.domains.crew.domain.CrewMemberRole;
-// import com.dongsan.domain.domains.crew.domain.PublicCrew;
-// import com.dongsan.domain.domains.crew.infrastructure.CrewCoreRepository;
-// import com.dongsan.domain.domains.crew.infrastructure.CrewMemberCoreRepository;
-// import com.dongsan.domain.domains.member.Member;
-// import com.dongsan.domain.domains.member.MemberCoreRepository;
-// import com.dongsan.domain.domains.member.MemberRole;
-//
-// class CowalkPostFacadeTest extends IntegrationTest {
-//
-//     @Autowired
-//     private CowalkPostFacade cowalkPostFacade;
-//
-//     @Autowired
-//     private CowalkParticipantCoreRepository cowalkParticipantRepository;
-//
-//     @Autowired
-//     private CowalkPostCoreRepository cowalkPostRepository;
-//
-//     @Autowired
-//     private MemberCoreRepository memberRepository;
-//
-//     @Autowired
-//     private CrewMemberCoreRepository crewMemberRepository;
-//
-//     @Autowired
-//     private CrewCoreRepository crewRepository;
-//
-//     @BeforeEach
-//     void setUpPost() {
-//
-//         Capacity capacity = new Capacity(false, 100);
-//         Crew crew = new PublicCrew("name", "description", "rule", "image", capacity);
-//
-//         crewRepository.save(crew);
-//
-//         for (int i = 0; i < 1000; i++) {
-//             Member member = memberRepository.save("email", "nickname", "profile", MemberRole.ROLE_USER, Provider.KAKAO);
-//             crewMemberRepository.save(
-//                     new CrewMember(crew.getId(), member.getId(), CrewMemberRole.PARTICIPANT)
-//             );
-//         }
-//
-//         // given
-//         Integer limit = 100;
-//         Long crewId = 1L;
-//         Long memberId = 1L;
-//
-//         CreateCowalkPostCommand command
-//                 = new CreateCowalkPostCommand(crewId, memberId, LocalDate.now(), LocalTime.now(), limit);
-//
-//         // 참가 최대 인원 30인 게시글 생성
-//         CowalkPost post = new CowalkPost(command);
-//         cowalkPostRepository.save(post);
-//     }
-//
-//     @Test
-//     void 동시에_1000명이_참여하면_100명만_저장된다() throws InterruptedException {
-//         int executeCount = 1000;
-//         ExecutorService executor = Executors.newFixedThreadPool(32);
-//         CountDownLatch latch = new CountDownLatch(executeCount);
-//
-//         for (int i = 0; i < executeCount; i++) {
-//             final long memberId = i + 1;
-//             executor.execute(() -> {
-//                 try {
-//                     cowalkPostFacade.joinCowalkPost(1L, 1L, memberId);
-//                 } catch (Exception ignored) {
-//                 } finally {
-//                     latch.countDown();
-//                 }
-//             });
-//         }
-//
-//         latch.await();
-//         executor.shutdown();
-//
-//         // 결과 확인
-//         Integer count = cowalkParticipantRepository.countByCowalkPostId(1L);
-//         assertThat(count).isEqualTo(100);
-//     }
-// }
+package com.dongsan.api.domains.cowalk;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.dongsan.api.support.IntegrationTest;
+import com.dongsan.api.support.factory.CrewFactory;
+import com.dongsan.domain.domains.auth.Provider;
+import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
+import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
+import com.dongsan.domain.domains.cowalk.infrastructure.CowalkParticipantCoreRepository;
+import com.dongsan.domain.domains.cowalk.infrastructure.CowalkPostCoreRepository;
+import com.dongsan.domain.domains.crew.domain.CrewExposeLevel;
+import com.dongsan.domain.domains.crew.domain.CrewMember;
+import com.dongsan.domain.domains.crew.domain.CrewMemberRole;
+import com.dongsan.domain.domains.crew.infrastructure.CrewCoreRepository;
+import com.dongsan.domain.domains.crew.infrastructure.CrewMemberCoreRepository;
+import com.dongsan.domain.domains.member.Member;
+import com.dongsan.domain.domains.member.MemberCoreRepository;
+import com.dongsan.domain.domains.member.MemberRole;
+
+class CowalkPostFacadeTest extends IntegrationTest {
+
+    @Autowired
+    private CowalkPostFacade cowalkPostFacade;
+
+    @Autowired
+    private CowalkParticipantCoreRepository cowalkParticipantRepository;
+
+    @Autowired
+    private CowalkPostCoreRepository cowalkPostRepository;
+
+    @Autowired
+    private MemberCoreRepository memberRepository;
+
+    @Autowired
+    private CrewMemberCoreRepository crewMemberRepository;
+
+    @Autowired
+    private CrewCoreRepository crewRepository;
+
+    @Autowired
+    private CrewFactory crewFactory;
+
+    @BeforeEach
+    void setUpPost() {
+
+        Member manager = memberRepository.save("email", "nickname", "profile", MemberRole.ROLE_USER, Provider.KAKAO);
+        Long crewId = crewFactory.save(CrewExposeLevel.PUBLIC, manager.getId());
+
+        for (int i = 0; i < 5; i++) {
+            Member member = memberRepository.save("email", "nickname", "profile", MemberRole.ROLE_USER, Provider.KAKAO);
+            crewMemberRepository.save(
+                    new CrewMember(crewId, member.getId(), CrewMemberRole.PARTICIPANT)
+            );
+        }
+
+        // given
+        Integer limit = 3;
+        Long memberId = 1L;
+
+        CreateCowalkPostCommand command
+                = new CreateCowalkPostCommand(crewId, memberId, LocalDateTime.now(), LocalDateTime.now(), limit, "test");
+
+        // 참가 최대 인원 limit인 게시글 생성
+        CowalkPost post = new CowalkPost(command);
+        cowalkPostRepository.save(post);
+    }
+
+    @Test
+    void 동시에_5명이_참여하면_3명만_저장된다() throws InterruptedException {
+        int executeCount = 5;
+        ExecutorService executor = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(executeCount);
+
+        for (int i = 0; i < executeCount; i++) {
+            final long memberId = i + 1;
+            executor.execute(() -> {
+                try {
+                    cowalkPostFacade.joinCowalkPost(1L, 1L, memberId);
+                } catch (Exception ignored) {
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executor.shutdown();
+
+        // 결과 확인
+        Integer count = cowalkParticipantRepository.countByCowalkPostId(1L);
+        assertThat(count).isEqualTo(3);
+    }
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkPostFacadeTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/CowalkPostFacadeTest.java
@@ -9,6 +9,8 @@ import java.util.concurrent.Executors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.dongsan.api.support.IntegrationTest;
@@ -29,6 +31,7 @@ import com.dongsan.domain.domains.member.MemberRole;
 
 class CowalkPostFacadeTest extends IntegrationTest {
 
+    private static final Logger log = LoggerFactory.getLogger(CowalkPostFacadeTest.class);
     @Autowired
     private CowalkPostFacade cowalkPostFacade;
 
@@ -87,6 +90,7 @@ class CowalkPostFacadeTest extends IntegrationTest {
                 try {
                     cowalkPostFacade.joinCowalkPost(1L, 1L, memberId);
                 } catch (Exception ignored) {
+                    log.error(ignored.getMessage(), ignored);
                 } finally {
                     latch.countDown();
                 }

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/MyCowalkIntegrationTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/MyCowalkIntegrationTest.java
@@ -1,0 +1,56 @@
+package com.dongsan.api.domains.cowalk;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.dongsan.api.domains.cowalk.dto.response.GetMyCowalkResponse;
+import com.dongsan.api.support.IntegrationTest;
+import com.dongsan.api.support.TestAuthHelper;
+import com.dongsan.api.support.factory.CowalkParticipantFactory;
+import com.dongsan.api.support.factory.CowalkPostFactory;
+import com.dongsan.api.support.factory.CrewFactory;
+import com.dongsan.domain.domains.crew.domain.CrewExposeLevel;
+import com.dongsan.domain.support.paging.CursorResponse;
+
+public class MyCowalkIntegrationTest extends IntegrationTest {
+    @Autowired
+    private TestAuthHelper authHelper;
+    @Autowired
+    private CrewFactory crewFactory;
+    @Autowired
+    private CowalkPostFactory cowalkPostFactory;
+    @Autowired
+    private CowalkParticipantFactory cowalkParticipantFactory;
+
+    @Test
+    void getMyCowalkTest() {
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        Long crewId = crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+        cowalkPostFactory.save(crewId, memberId);
+        cowalkParticipantFactory.save(1L, memberId);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<CursorResponse<GetMyCowalkResponse>> response = restTemplate.exchange(
+                "http://localhost:" + port + "/users/cowalk",
+                HttpMethod.GET,
+                entity,
+                new ParameterizedTypeReference<CursorResponse<GetMyCowalkResponse>>() {
+                }
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody().data().size());
+        Assertions.assertNotNull(response.getBody());
+    }
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/MyCowalkIntegrationTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/cowalk/MyCowalkIntegrationTest.java
@@ -21,7 +21,7 @@ import com.dongsan.api.support.factory.CrewFactory;
 import com.dongsan.domain.domains.crew.domain.CrewExposeLevel;
 import com.dongsan.domain.support.paging.CursorResponse;
 
-public class MyCowalkIntegrationTest extends IntegrationTest {
+class MyCowalkIntegrationTest extends IntegrationTest {
     @Autowired
     private TestAuthHelper authHelper;
     @Autowired

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/crew/CrewIntegrationTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/crew/CrewIntegrationTest.java
@@ -1,0 +1,380 @@
+package com.dongsan.api.domains.crew;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.dongsan.api.domains.crew.dto.response.CreateCrewImageResponse;
+import com.dongsan.api.domains.crew.dto.response.CreateCrewResponse;
+import com.dongsan.api.domains.crew.dto.response.GetCrewFeedResponse;
+import com.dongsan.api.domains.crew.dto.response.GetCrewInfoResponse;
+import com.dongsan.api.domains.crew.dto.response.GetCrewMemberRankingResponse;
+import com.dongsan.api.domains.crew.dto.response.GetCrewsResponse;
+import com.dongsan.api.domains.crew.dto.response.IsNameUniqueResponse;
+import com.dongsan.api.support.IntegrationTest;
+import com.dongsan.api.support.TestAuthHelper;
+import com.dongsan.api.support.factory.CrewFactory;
+import com.dongsan.api.support.factory.ImageFactory;
+import com.dongsan.api.support.factory.WalkwayFactory;
+import com.dongsan.api.support.factory.WalkwayLogFactory;
+import com.dongsan.domain.domains.crew.domain.CrewExposeLevel;
+import com.dongsan.domain.domains.crew.domain.CrewMemberRole;
+import com.dongsan.domain.support.paging.CursorResponse;
+import com.dongsan.file.service.S3FileService;
+
+public class CrewIntegrationTest extends IntegrationTest {
+    @Autowired
+    private TestAuthHelper authHelper;
+    @Autowired
+    private CrewFactory crewFactory;
+    @Autowired
+    private WalkwayFactory walkwayFactory;
+    @Autowired
+    private ImageFactory imageFactory;
+    @Autowired
+    private WalkwayLogFactory walkwayLogFactory;
+    @MockBean
+    private S3FileService s3FileService;
+
+    @Test
+    void isNameUniqueTest_unique() {
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<IsNameUniqueResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/exists?crewId=1&name=test",
+                HttpMethod.GET,
+                entity,
+                IsNameUniqueResponse.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertThat(response.getBody().isValid()).isTrue();
+    }
+
+    @Test
+    void isNameUniqueTest_not_unique() {
+        Long memberId = 1L;
+        Long otherMemberId = 2L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+        crewFactory.save("중복이름", CrewExposeLevel.PUBLIC, otherMemberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<IsNameUniqueResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/exists?crewId=1&name=중복이름",
+                HttpMethod.GET,
+                entity,
+                IsNameUniqueResponse.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertThat(response.getBody().isValid()).isFalse();
+    }
+
+
+    @Test
+    void isNameUniqueTest_crew_not_exists() {
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<IsNameUniqueResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/exists?crewId=999&name=test",
+                HttpMethod.GET,
+                entity,
+                IsNameUniqueResponse.class
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+
+    @Test
+    void getCrewInfoTest() {
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        Long crewId = crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+        imageFactory.save("https://example.com/crew.png");
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<GetCrewInfoResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/"+ crewId +"/info",
+                HttpMethod.GET,
+                entity,
+                GetCrewInfoResponse.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+    }
+
+    @Test
+    void getCrewInfoTest_crew_not_exists() {
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        Long crewId = 999L;
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<GetCrewInfoResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/"+ crewId +"/info",
+                HttpMethod.GET,
+                entity,
+                GetCrewInfoResponse.class
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    void getCrewFeedTest() {
+        Long memberId = 1L;
+        imageFactory.save();
+        Long walkwayId = walkwayFactory.save();
+        Long crewId = crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+        walkwayLogFactory.save(memberId, walkwayId, 300, 0.2);
+
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<CursorResponse<GetCrewFeedResponse>> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/" + crewId + "/feeds",
+                HttpMethod.GET,
+                entity,
+                new ParameterizedTypeReference<CursorResponse<GetCrewFeedResponse>>() {
+                }
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody().data().size());
+    }
+
+    @Test
+    void getCrewMemberRankingTest() {
+        Long memberId = 1L;
+        imageFactory.save();
+        Long walkwayId = walkwayFactory.save();
+        Long crewId = crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+        walkwayLogFactory.save(memberId, walkwayId, 300, 0.2);
+
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<CursorResponse<GetCrewMemberRankingResponse>> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/" + crewId + "/ranking?period=daily&date=" + LocalDate.now() + "&sort=distance",
+                HttpMethod.GET,
+                entity,
+                new ParameterizedTypeReference<CursorResponse<GetCrewMemberRankingResponse>>() {
+                }
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody().data().size());
+    }
+
+    @Test
+    void createCrewTest() {
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+
+        String jsonBody = """
+                {
+                    "name": "테스트 크루",
+                    "description": "크루 설명",
+                    "rule": "크루 규칙",
+                    "visibility": "PUBLIC",
+                    "password": "12345678",
+                    "limitEnable": true,
+                    "memberLimit": 50,
+                    "crewImageId": null
+                }
+                """;
+        HttpEntity<String> entity = new HttpEntity<>(jsonBody, headers);
+
+        ResponseEntity<CreateCrewResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews",
+                HttpMethod.POST,
+                entity,
+                CreateCrewResponse.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void createCrewImage() {
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+
+        given(s3FileService.saveFile(any(MultipartFile.class)))
+                .willReturn("https://test/");
+
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+        ByteArrayResource resource = new ByteArrayResource("fakeImage".getBytes()) {
+            @Override
+            public String getFilename() {
+                return "crew.png";
+            }
+        };
+
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("crewImage", resource);
+
+        ResponseEntity<CreateCrewImageResponse> response = restTemplate.postForEntity(
+                "http://localhost:" + port + "/crews/image",
+                new HttpEntity<>(body, headers),
+                CreateCrewImageResponse.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assertions.assertNotNull(response.getBody());
+    }
+
+    @Test
+    void joinCrewTest() {
+        Long managerMemberId = 2L;
+        Long crewId = crewFactory.save(CrewExposeLevel.PUBLIC, managerMemberId);
+
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+
+        String jsonBody = """
+                {
+                    "password": "1234"
+                }
+                """;
+        HttpEntity<String> entity = new HttpEntity<>(jsonBody, headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/" + crewId + "/members",
+                HttpMethod.POST,
+                entity,
+                Void.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void updateCrewTest() {
+        Long memberId = 1L;
+        Long crewId = crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+
+        String jsonBody = """
+                {
+                    "name": "이름변경",
+                    "description": "설명변경",
+                    "rule": "규칙변경",
+                    "visibility": "PUBLIC",
+                    "password": "12345678",
+                    "limitEnable": true,
+                    "memberLimit": 50,
+                    "crewImageId": null
+                }
+                """;
+        HttpEntity<String> entity = new HttpEntity<>(jsonBody, headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/" + crewId,
+                HttpMethod.PUT,
+                entity,
+                Void.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void leaveCrewTest() {
+        Long managerMemberId = 2L;
+        Long crewId = crewFactory.save(CrewExposeLevel.PUBLIC, managerMemberId);
+
+        Long memberId = 1L;
+        crewFactory.saveMember(memberId, crewId, CrewMemberRole.MEMBER);
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/" + crewId + "/members",
+                HttpMethod.DELETE,
+                entity,
+                Void.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void searchCrewsTest() {
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+
+        crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+        imageFactory.save("https://example.com/crew.png");
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<CursorResponse<GetCrewsResponse>> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/search?name=테스트",
+                HttpMethod.GET,
+                entity,
+                new ParameterizedTypeReference<CursorResponse<GetCrewsResponse>>() {
+                }
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody().data().size());
+    }
+
+    @Test
+    void recommendCrewsTest() {
+        Long memberId = 1L;
+        imageFactory.save();
+
+        Long crewManagerId = 2L;
+        Long crewId = crewFactory.save(CrewExposeLevel.PUBLIC, crewManagerId);
+        crewFactory.saveMetaCrewRanking(crewId, 10L);
+
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<CursorResponse<GetCrewsResponse>> response = restTemplate.exchange(
+                "http://localhost:" + port + "/crews/recommend",
+                HttpMethod.GET,
+                entity,
+                new ParameterizedTypeReference<CursorResponse<GetCrewsResponse>>() {
+                }
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody().data().size());
+    }
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/crew/CrewIntegrationTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/crew/CrewIntegrationTest.java
@@ -41,7 +41,7 @@ import com.dongsan.domain.domains.crew.domain.CrewMemberRole;
 import com.dongsan.domain.support.paging.CursorResponse;
 import com.dongsan.file.service.S3FileService;
 
-public class CrewIntegrationTest extends IntegrationTest {
+class CrewIntegrationTest extends IntegrationTest {
     @Autowired
     private TestAuthHelper authHelper;
     @Autowired

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/crew/MyCrewIntegrationTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/crew/MyCrewIntegrationTest.java
@@ -1,0 +1,77 @@
+package com.dongsan.api.domains.crew;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.dongsan.api.domains.crew.dto.response.GetCrewsResponse;
+import com.dongsan.api.domains.crew.dto.response.GetMyCrewIdsResponse;
+import com.dongsan.api.support.IntegrationTest;
+import com.dongsan.api.support.TestAuthHelper;
+import com.dongsan.api.support.factory.CrewFactory;
+import com.dongsan.api.support.factory.ImageFactory;
+import com.dongsan.api.support.factory.WalkwayFactory;
+import com.dongsan.api.support.factory.WalkwayLogFactory;
+import com.dongsan.domain.domains.crew.domain.CrewExposeLevel;
+import com.dongsan.domain.support.paging.CursorResponse;
+import com.dongsan.file.service.S3FileService;
+
+public class MyCrewIntegrationTest extends IntegrationTest {
+    @Autowired
+    private TestAuthHelper authHelper;
+    @Autowired
+    private CrewFactory crewFactory;
+    @Autowired
+    private WalkwayFactory walkwayFactory;
+    @Autowired
+    private ImageFactory imageFactory;
+    @Autowired
+    private WalkwayLogFactory walkwayLogFactory;
+    @MockBean
+    private S3FileService s3FileService;
+
+    @Test
+    void getMyCrewsTest() {
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<CursorResponse<GetCrewsResponse>> response = restTemplate.exchange(
+                "http://localhost:" + port + "/users/crews",
+                HttpMethod.GET,
+                entity,
+                new ParameterizedTypeReference<CursorResponse<GetCrewsResponse>>() {
+                }
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody().data().size());
+    }
+
+    @Test
+    void getMyCrewIdsTest() {
+        Long memberId = 1L;
+        HttpHeaders headers = authHelper.generateTokenHeader(memberId);
+        crewFactory.save(CrewExposeLevel.PUBLIC, memberId);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<GetMyCrewIdsResponse> response = restTemplate.exchange(
+                "http://localhost:" + port + "/users/crews/ids",
+                HttpMethod.GET,
+                entity,
+                GetMyCrewIdsResponse.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody().crewIds().size());
+    }
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/domains/crew/MyCrewIntegrationTest.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/domains/crew/MyCrewIntegrationTest.java
@@ -24,7 +24,7 @@ import com.dongsan.domain.domains.crew.domain.CrewExposeLevel;
 import com.dongsan.domain.support.paging.CursorResponse;
 import com.dongsan.file.service.S3FileService;
 
-public class MyCrewIntegrationTest extends IntegrationTest {
+class MyCrewIntegrationTest extends IntegrationTest {
     @Autowired
     private TestAuthHelper authHelper;
     @Autowired

--- a/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/CowalkCommentFactory.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/CowalkCommentFactory.java
@@ -1,0 +1,17 @@
+package com.dongsan.api.support.factory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.dongsan.domain.domains.cowalk.domain.CowalkComment;
+import com.dongsan.domain.domains.cowalk.domain.CowalkCommentRepository;
+
+@Component
+public class CowalkCommentFactory {
+    @Autowired
+    private CowalkCommentRepository cowalkCommentRepository;
+
+    public void save(Long cowalkPostId, Long memberId) {
+        cowalkCommentRepository.save(new CowalkComment(cowalkPostId, memberId, "test comment"));
+    }
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/CowalkParticipantFactory.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/CowalkParticipantFactory.java
@@ -1,0 +1,17 @@
+package com.dongsan.api.support.factory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.dongsan.domain.domains.cowalk.domain.CowalkParticipant;
+import com.dongsan.domain.domains.cowalk.domain.CowalkParticipantRepository;
+
+@Component
+public class CowalkParticipantFactory {
+    @Autowired
+    private CowalkParticipantRepository cowalkParticipantRepository;
+
+    public void save(Long cowalkPostId, Long memberId) {
+        cowalkParticipantRepository.save(new CowalkParticipant(cowalkPostId, memberId));
+    }
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/CowalkPostFactory.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/CowalkPostFactory.java
@@ -1,0 +1,22 @@
+package com.dongsan.api.support.factory;
+
+import java.time.LocalDateTime;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.dongsan.domain.domains.cowalk.CreateCowalkPostCommand;
+import com.dongsan.domain.domains.cowalk.domain.CowalkPost;
+import com.dongsan.domain.domains.cowalk.domain.CowalkPostRepository;
+
+@Component
+public class CowalkPostFactory {
+    @Autowired
+    private CowalkPostRepository cowalkPostRepository;
+
+    public void save(Long crewId, Long memberId) {
+        LocalDateTime now = LocalDateTime.now();
+        CreateCowalkPostCommand command = new CreateCowalkPostCommand(crewId, memberId, now, now.plusHours(1), 10, "test");
+        cowalkPostRepository.save(new CowalkPost(command));
+    }
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/CrewFactory.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/CrewFactory.java
@@ -1,0 +1,117 @@
+package com.dongsan.api.support.factory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.dongsan.domain.domains.crew.domain.Capacity;
+import com.dongsan.domain.domains.crew.domain.Crew;
+import com.dongsan.domain.domains.crew.domain.CrewAccessPolicy;
+import com.dongsan.domain.domains.crew.domain.CrewExposeLevel;
+import com.dongsan.domain.domains.crew.domain.CrewInfo;
+import com.dongsan.domain.domains.crew.domain.CrewMember;
+import com.dongsan.domain.domains.crew.domain.CrewMemberRepository;
+import com.dongsan.domain.domains.crew.domain.CrewMemberRole;
+import com.dongsan.domain.domains.crew.domain.CrewRepository;
+import com.dongsan.domain.domains.crew.service.PasswordHasher;
+
+@Component
+public class CrewFactory {
+    private static final String DEFAULT_NAME        = "테스트 크루";
+    private static final String DEFAULT_DESCRIPTION = "설명입니다";
+    private static final String DEFAULT_RULE        = "규칙입니다";
+    private static final String DEFAULT_IMAGE_URL   = "https://example.com/crew.png";
+    private static final boolean DEFAULT_LIMIT_ENABLE = true;
+    private static final int DEFAULT_MEMBER_LIMIT     = 50;
+    private static final String DEFAULT_PRIVATE_PASSWORD = "1234";
+
+    @Autowired
+    private CrewRepository crewRepository;
+    @Autowired
+    private CrewMemberRepository crewMemberRepository;
+    @Autowired
+    private PasswordHasher passwordHasher;
+    @Autowired
+    DataSource dataSource;
+
+    public Long save(CrewExposeLevel crewExposeLevel, Long memberId) {
+        CrewInfo info = new CrewInfo(
+                DEFAULT_NAME,
+                DEFAULT_DESCRIPTION,
+                DEFAULT_RULE,
+                DEFAULT_IMAGE_URL
+        );
+
+        Capacity capacity = new Capacity(
+                DEFAULT_LIMIT_ENABLE,
+                DEFAULT_MEMBER_LIMIT
+        );
+
+        CrewAccessPolicy accessPolicy = switch (crewExposeLevel) {
+            case PUBLIC -> CrewAccessPolicy.publicCrew();
+            case PRIVATE -> {
+                String hashed = passwordHasher.hash(DEFAULT_PRIVATE_PASSWORD);
+                yield CrewAccessPolicy.privateCrew(hashed);
+            }
+        };
+
+        Crew crew = new Crew(info, capacity, accessPolicy);
+        crewRepository.save(crew);
+
+        crewMemberRepository.save(new CrewMember(crew.getId(), memberId, CrewMemberRole.MANAGER));
+        return crew.getId();
+    }
+
+    public Long save(String name, CrewExposeLevel crewExposeLevel, Long memberId) {
+        CrewInfo info = new CrewInfo(
+                name,
+                DEFAULT_DESCRIPTION,
+                DEFAULT_RULE,
+                DEFAULT_IMAGE_URL
+        );
+
+        Capacity capacity = new Capacity(
+                DEFAULT_LIMIT_ENABLE,
+                DEFAULT_MEMBER_LIMIT
+        );
+
+        CrewAccessPolicy accessPolicy = switch (crewExposeLevel) {
+            case PUBLIC -> CrewAccessPolicy.publicCrew();
+            case PRIVATE -> {
+                String hashed = passwordHasher.hash(DEFAULT_PRIVATE_PASSWORD);
+                yield CrewAccessPolicy.privateCrew(hashed);
+            }
+        };
+
+        Crew crew = new Crew(info, capacity, accessPolicy);
+        crewRepository.save(crew);
+
+        crewMemberRepository.save(new CrewMember(crew.getId(), memberId, CrewMemberRole.MANAGER));
+        return crew.getId();
+    }
+
+    public void saveMember(Long memberId, Long crewId, CrewMemberRole crewMemberRole) {
+        crewMemberRepository.save(new CrewMember(crewId, memberId, crewMemberRole));
+    }
+
+    public void saveMetaCrewRanking(Long crewId, Long logCount) {
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement ps = conn.prepareStatement(
+                     """
+                             INSERT 
+                             INTO meta_crew_ranking (crew_id, log_count, created_at, updated_at) 
+                             VALUES (?, ?, NOW(), NOW())
+                             """)
+        ) {
+            ps.setLong(1, crewId);   // crew_id
+            ps.setLong(2, logCount);   // log_count
+            ps.executeUpdate();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/ImageFactory.java
+++ b/dongsan-external-api/src/test/java/com/dongsan/api/support/factory/ImageFactory.java
@@ -15,4 +15,8 @@ public class ImageFactory {
     public Long save() {
         return imageRepository.save(DEFAULT_IMAGE_URL);
     }
+
+    public Long save(String imageUrl) {
+        return imageRepository.save(imageUrl);
+    }
 }

--- a/dongsan-external-api/src/test/resources/reset.sql
+++ b/dongsan-external-api/src/test/resources/reset.sql
@@ -19,6 +19,22 @@ DELETE
 FROM walkway;
 DELETE
 FROM walkway_log;
+DELETE
+FROM cowalk_comment;
+DELETE
+FROM cowalk_participant;
+DELETE
+FROM cowalk_post;
+DELETE
+FROM crew;
+DELETE
+FROM crew_member;
+DELETE
+FROM meta_crew_ranking;
+DELETE
+FROM meta_walkway_liked;
+DELETE
+FROM meta_walkway_rating;
 
 -- AUTO_INCREMENT 초기화
 ALTER TABLE bookmark AUTO_INCREMENT = 1;
@@ -29,6 +45,15 @@ ALTER TABLE member AUTO_INCREMENT = 1;
 ALTER TABLE review AUTO_INCREMENT = 1;
 ALTER TABLE walkway AUTO_INCREMENT = 1;
 ALTER TABLE walkway_log AUTO_INCREMENT = 1;
+ALTER TABLE cowalk_comment AUTO_INCREMENT = 1;
+ALTER TABLE cowalk_participant AUTO_INCREMENT = 1;
+ALTER TABLE cowalk_post AUTO_INCREMENT = 1;
+ALTER TABLE crew AUTO_INCREMENT = 1;
+ALTER TABLE crew_member AUTO_INCREMENT = 1;
+ALTER TABLE meta_crew_ranking AUTO_INCREMENT = 1;
+ALTER TABLE meta_walkway_liked AUTO_INCREMENT = 1;
+ALTER TABLE meta_walkway_rating AUTO_INCREMENT = 1;
+
 
 -- 외래 키 제약 조건 다시 활성화
 SET
@@ -39,5 +64,12 @@ INSERT INTO member (created_at, email, nickname, provider, role)
 VALUES (NOW(),
         'dongsan@example.com',
         '테스트유저',
+        'KAKAO',
+        'ROLE_USER');
+
+INSERT INTO member (created_at, email, nickname, provider, role)
+VALUES (NOW(),
+        'ddongsan@example.com',
+        '다른유저',
         'KAKAO',
         'ROLE_USER');


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

## 📄 Work Description
<strong>Jira Ticket : `DB-370`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. 통합 테스트 코드 작성
<img width="433" height="314" alt="image" src="https://github.com/user-attachments/assets/9b7779b2-fb19-478a-ae04-7b8ea46d805c" />
<img width="442" height="437" alt="image" src="https://github.com/user-attachments/assets/26f57f18-ecbc-48c7-a1f2-db71c8a42954" />

크루, 같이 산책 통합 테스트를 작성했습니다.


<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->


<br/>

## 🔗 Reference
[//]: # (문제를 해결하면서 도움이 되었거나 참고했던 사이트 또는 코드 첨부)
