### PR TITLE
[fix/DB-382]: 같이 산책 댓글 작성 수정, s3 테스트 코드

### DIFF
--- a/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
+++ b/dongsan-external-api/src/main/java/com/dongsan/api/domains/cowalk/CowalkPostFacade.java
@@ -113,7 +113,7 @@ public class CowalkPostFacade {
     @Transactional
     public Long saveCowalkComment(Long memberId, Long cowalkPostId,
                                   CreateCowalkCommentRequest createCowalkCommentRequest) {
-        cowalkParticipantRdbService.validNotJoin(cowalkPostId, memberId);
+        cowalkParticipantRdbService.validNotJoin(memberId, cowalkPostId);
         return cowalkCommentRdbService.save(memberId, cowalkPostId, createCowalkCommentRequest.content());
     }
 

--- a/dongsan-infra/infra-file/build.gradle
+++ b/dongsan-infra/infra-file/build.gradle
@@ -5,9 +5,6 @@ dependencies {
     // Multipart
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
-
 }
 
 // application.yml 설정 파일 복사

--- a/dongsan-infra/infra-file/build.gradle
+++ b/dongsan-infra/infra-file/build.gradle
@@ -5,6 +5,9 @@ dependencies {
     // Multipart
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+
 }
 
 // application.yml 설정 파일 복사
@@ -12,6 +15,10 @@ tasks.register('copyConfig', Copy) {
     from '../../Config'
     include "application-s3.yml"
     into 'src/main/resources'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 processResources.dependsOn('copyConfig')

--- a/dongsan-infra/infra-file/src/test/java/com/dongsan/file/service/S3FileServiceIntegrationTest.java
+++ b/dongsan-infra/infra-file/src/test/java/com/dongsan/file/service/S3FileServiceIntegrationTest.java
@@ -1,0 +1,62 @@
+package com.dongsan.file.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.dongsan.file.config.S3Config;
+
+@SpringBootTest(classes = { S3FileService.class, S3Config.class })
+@ActiveProfiles({"dev", "s3"})
+class S3FileServiceIntegrationTest {
+
+    @Autowired
+    private S3FileService s3FileService;
+
+    @Autowired
+    private AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private String uploadedKey;
+
+    @AfterEach
+    void tearDown() {
+        if (uploadedKey != null) {
+            amazonS3.deleteObject(bucket, uploadedKey);
+        }
+    }
+
+    @Test
+    void saveFile_실제S3_업로드_URL반환_및_객체존재확인() throws Exception {
+        byte[] bytes = ("hello s3 " + UUID.randomUUID()).getBytes(StandardCharsets.UTF_8);
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "sample.png",
+                "image/png",
+                bytes
+        );
+
+        String url = s3FileService.saveFile(file);
+
+        assertThat(url).isNotBlank();
+
+        // 업로드된 key 추출 (마지막 / 뒤)
+        String key = url.substring(url.lastIndexOf('/') + 1);
+        uploadedKey = key;
+
+        // 실제 객체 존재 여부
+        assertThat(amazonS3.doesObjectExist(bucket, key)).isTrue();
+    }
+}


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [feature/DB-1]: 로그 설정)

## 📄 Work Description
<strong>Jira Ticket : `DB-382`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. 같이 산책 댓글 에러 수정
<img width="740" height="128" alt="image" src="https://github.com/user-attachments/assets/6597d65c-cdf2-46ba-9052-ac3b065323f1" />

`validNotJoin` 의 `memberId`, `cowalkPostId`가 반대로 되어 있어서 수정했습니다.

#### 2. S3 테스트 코드 작성
<img width="673" height="890" alt="image" src="https://github.com/user-attachments/assets/61e783ac-e114-474e-b9fe-4347ff326985" />

s3 저장 테스트 코드를 작성했습니다.
파일을 저장하고 존재 여부를 확인한 후, `AfterEach`에서 저장한 파일을 삭제합니다.

<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->


<br/>

## 🔗 Reference
[//]: # (문제를 해결하면서 도움이 되었거나 참고했던 사이트 또는 코드 첨부)
